### PR TITLE
update README, move api and guides to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,234 +1,83 @@
 # react-i13n
 
-React I13n provides a performant and scalable approach to instrumentation.
+`react-i13n` provides a performant and scalable approach to instrumentation.
 
-In most cases, you have to manage the `instrumentation model data` you want and send out beacons separately, by using `react-i13n`, you have a better way to manage beacons with an inheritance architecture.
+In most cases, you will have to manually add the code to what you want to track, e.g., you have to hook `onClick` to the links you want to track. `react-i13n` provide a convenient approach for you to do the instrumentation, all you have to do is to define the data model you want to beacon out.
 
-Also, if you want to track a link click, you will not have to hook the click event and send out event beacon. We provide React components to handle this for you, all you need to do is define the data model you want to beacon out.
+Moreover, we provide a mechanism to build the `instrumentation tree`, typically you might have to manage the `instrumentation model data` you want and send out beacons separately, by using `react-i13n`, you have a better way to manage beacon data with an inheritance architecture, refer to [integrate with components](./docs/guides/integrateWithComponents.md) to see how do we get the benifit of `react-i13n`.
+
+It's originated from [Rafael Martins](http://www.slideshare.net/RafaelMartins21/instrumentation-talk-39547608). More implement detail please refer to [Main Ideas](./docs/guides/mainIdeas.md) section.
+
+## Features
+
+* Provides [createI13nNode](./docs/api/createI13nNode.md#createi13nnodecomponent-options) and [I13nMixin](./docs/api/createI13nNode.md#i13nmixin) to generate components as an easy way to track the links.
+* By integrating the tree architecture, you can get instrumentation data efficiently, and you can integrate the inherit architecture to manage them.
+* `react-i13n` is pluggable to integrate any data analytics library into the same tree architecture. All that is needed is to implement the plugin and the handler functions which integrate with the libraries transport functions.
+* `i13nModel` could be a plain object or a `dynamic function` with a proper `i13nModel` object return, which means you can dynamically change `i13nModel` data without causing re-render due to the `props` changes.
+* All the components we provide are harmony with both server side and client side, If you are using isomorphic framework to build your app, you could get some events e.g., `pageview` on both server and client side, which means you could select a prefer way to handle the event.
+* We integrate the viewport checking and set the status in each `I13nNode`, it could be used to know if you want to send out the data only when node is in viewport.
 
 ## Main Ideas
-It's originated from [Rafael Martins](http://www.slideshare.net/RafaelMartins21/instrumentation-talk-39547608).
-
 `react-i13n` utilizes the life cycle events provided by `React` to build an i13n tree that mirrors the React component hierarchy. This approach optimizes for performance by reducing the need to scrape the DOM for data before beaconing.
 
-`react-i13n` is pluggable to integrate any data analytics library into the same tree architecture. All that is needed is to implement the plugin and the handler functions which integrate with the libraries transport functions.
-
 ### I13n Tree
-* `react-i13n` build the `I13n Tree` with `context` and life cycle event `componentWillMount`, we could define the `i13nModel` data we need. Which means we don't need addtional DOM manipulation when we want to get `i13nModel` values for sending out linkview/click beacon.
-* `i13nModel` could be a plain object or a dynamic function with a proper `i13nModel` object return, which means we could dynamically change `i13nModel` data without causing rerender due to the `props` changes.
-* Whenever we want to get the `i13nModel` for certain node, it traverses back to the root and merge all the `i13nModel` information in the path. Since the tree is already built and we don't need extra DOM access, it should be pretty cheap and efficient. 
+* `react-i13n` build the `I13n Tree` with `context` and life cycle event `componentWillMount`, we can define the `i13nModel` data we need. Which means we don't need additional DOM manipulation when we want to get `i13nModel` values for sending out beacons for the link.
 
-### I13n Node
-* The node in i13n Tree, it will be passed with the `payload` to the handler function, it provides APIs for users to get the informations needed for beaconing.
-* `i13nNode.getModel` - get the i13nModel data of the node.
-* `i13nNode.getMergedModel` - get the model data which is traversed and combined to the root.
-* `i13nNode.getPosition` - get the position of its parent.
-* `i13nNode.getText` - get the inner text value of that node.
-* `i13nNode.isTraversed` - get is traversed or not.
-* `i13nNode.isInViewport` - get is in viewport or not, if we didn't enable viewport checking, it will always be true
-* `i13nNode.traverseNodes` - recursively traverse the nodes and users could pass handler into the function to do what they need, like gathering links.
-
-### Isomorphic
-All the components we provide are harmony with both server side and client side, If you are using isomorphic framework to build your app, you could get some events e.g., `pageview` on both server and client side, which means you could select a prefer way to handle the event. 
-
-### Viewport Checking
-We integrate the viewport checking and set the status in each `I13nNode`, it could be used to know if you want to send out the data only when node is in viewport.
+### Inherit Architecture
+* We can define i13n data for each level, whenever we want to get the `i13nModel` for certain node, it traverses back to the root and merge all the `i13nModel` information in the path. Since the tree is already built and we don't need extra DOM access, it should be pretty cheap and efficient. 
 
 ## Install
+
 ```
 npm install react-i13n
 ```
 
 ## Usage
 
-### Init ReactI13n
-We provide `setupI13n` as a convenient `higher order function` to setup the ReactI13n, you will need to pass your `top level component`, `options`, and `plugins` into. It takes care of creating a `ReactI13n` instance and setup the plugins. Just use the function to create a component then render it.
-* `Component` - the top level component
-* `options` - the options passed into ReactI13n
-* `options.rootModelData` - defined the `i13nModel` data of the root.
-* `options.I13nNodeClass` - you can inherit the `I13nNode` and add the functionality you need, just pass the class.
-* `options.isViewportEnabled` - define if you want to enable the viewport checking.
-* `plugins` - plugins array that you defined according to the definition below.
-
-### Implement the plugin.
-A valid plugin must contains
-* `name` - the plugin name
-* `eventHandlers` - handlers functions for the events, typically in the eventHandler function we would send out a tracking beacon, now `react-i13n` has `click`, `created` and `enterViewport`, you can define the events you need and implement the handlers function, e.g., `pageview`.
-    * `click` - happens when user click a `I13nComponent` with `ClickHandler`
-    * `created` - happens when the `I13nComponent` is created
-    * `enterViewport` - happens when the `isViewportEnabled` is true and the node enter the viewport
-
-All the `eventHandler` would receive a `payload` object and a `callback` function, in payload you will get:
-* `payload.I13nNode` - the I13n node related to the event, then you could use the APIs provided by `I13nNode` to get the information you need.
-* `payload.env` - `server` or `client`, some events e.g., `pageview` will fire on both server and client side, you can define the prefer way you want to handle the beacon.
+* Implement the [plugin](./docs/guides/createPlugins.md) for your preferred instrumentation mechanism.
+* Use [setupI13n](./docs/api/setupI13n.md) to create a top level component.
+* Define your instrumentation data and [integrate with your components](./docs/guides/integrateWithComponents.md)
+* Follow the [event system](./docs/guides/eventSystem.md) if you want to fire events manually.
 
 ```js
 var React = require('react/addons');
 var ReactI13n = require('react-i13n').ReactI13n;
 var setupI13n = require('react-i13n').setupI13n;
-// define the plugin
-var gaPlugin = {
-    name: 'ga',
-    eventHandlers: {
-        click: function (payload, callback) {
-            // click handlers
-        },
-        event: function (payload, callback) {
-            // event handlers
-        },
-        pageview: function (payload, callback) {
-            if ('client' === payload.env) {
-                // client side pageview handlers
-            } else {
-                // server side pageview handlers
-            }
-        },
-        created: function (payload, callback) {
-            // created handlers
-        }
-    }
-};
+var somePlugin = require('some-i13n-plugin'); // a plugin for a certain instrumentation mechanism
+
+// create a i13n anchor for link tracking
+var createI13nNode = require('react-i13n').createI13nNode;
+var I13nAnchor = createI13nNode('a', {
+    isLeafNode: true,
+    bindClickEvent: true,
+    follow: true
+});
 
 var DemoApp = React.createClass({
     componentWillMount: function () {
-        // you could fire page view in componentWillMount, which means you could get a pv event on both server and client side, 
-        // then you could choose how to handle it.
-        ReactI13n.getInstance().execute('pageview', {});
+        ReactI13n.getInstance().execute('pageview', {}); // fire a custom event
+    },
+    render: function () {
+        ...
+        <I13nAnchor href="http://foo.bar" i13nModel={{action: 'click', label: 'foo'}}>...</I13nAnchor> 
+        // this link will be tracked, and the click event handlers provided the plugin will get the model data as 
+        // {site: 'foo', action: 'click', label: 'foo'}
     }
 });
 
-var I13nDempApp = setupI13n(DemoApp, options, [gaPlugin]);
+var I13nDempApp = setupI13n(DemoApp, {
+    rootModelData: {site: 'foo'},
+    isViewportEnabled: true
+}, [somePlugin]);
 // then you could use I13nDemoApp to render you app
-```
-
-### I13nMixin and createI13nNode
-Everything is done by the `i13n mixin`, which means if we want to create an component to be an `I13nNode`, we will have to add the `I13nMixin` into the component.
-You can pass the options with `props` to config what you want to do with this `I13nNode`.
-* `i13nModel` - the i13nModel data object or a dynamic function returns the data object
-* `isLeafNode` - define if it's a leaf node or not, we will fire `created` event for every node when it's created, `isLeafNode` will help us to know if we want to do the action. e.g, we might only want to send out beacons to record links. 
-* `bindClickEvent` - define if want to bind a click handler or not
-* `follow` - define if click handler need to redirect users to destination after sending beacon or not. You could set `follow=false` and the handler would send out beacon but will not redirect users.
-* you can pass all the props you need, we will pass them to the component
-
-```js
-var I13nMixin = require('react-i13n').I13nMixin;
-var Foo = React.createClass({
-    mixins: [I13nMixin]
-    ...
-});
-
-// in template
-<Foo i13nModel={i13nModel}>
-    // will create a i13n node for Foo
-    ...
-</Foo>
-```
-
-We also provide `createI13nNode` as a `higher order function` for you to wrap your component as an `I13nNode`
-* component - react component or string of native tag
-* options - options as the default props
-
-```js
-var createI13nNode = require('react-i13n').createI13nNode;
-var Foo = React.createClass({
-    ...
-});
-var I13nFoo = createI13nNode(Foo, {
-    isLeafNode: false,
-    bindClickEvent: false,
-    follow: false
-});
-// in template
-<I13nFoo i13nModel={i13nModel}>
-    // will create a i13n node for Foo
-    ...
-</I13nFoo>
-```
-
-If you want to track the links, you will need to create anchor with `createI13nNode` and enable the click tracking.
-
-```js
-var createI13nNode = require('react-i13n').createI13nNode;
-var I13nAnchor = createI13nNode('a', {
-    isLeafNode: true,
-    bindClickEvent: true,
-    follow: true
-});
-
-<I13nAnchor i13nModel={i13nModel}>
-    ...
-</I13nAnchor>
-```
-
-We are also able to pass i13nModel as a function to get dynamical generated data.
-
-```js
-var createI13nNode = require('react-i13n').createI13nNode;
-var I13nAnchor = createI13nNode('a', {
-    isLeafNode: true,
-    bindClickEvent: true,
-    follow: true
-});
-
-function getI13nModel: function () {
-    return {
-        // you can dynamical generate i13nModel data here based on the use case
-    };
-}
-
-<I13nAnchor i13nModel={getI13nModel}>
-    ...
-</I13nAnchor>
-```
-
-Other than links, you can create a middle tag with i13n functionalities.
-* Please not that since we integrate the feature of `parent-based context`, with `dev` env, react will generate warning like
-
-```js
-Warning: owner-based and parent-based contexts differ (values: [object Object] vs [object Object]) for key (parentI13nNode) while mounting I13nAnchor (see: http://fb.me/react-context-by-parent)
-```
-* This feature can only used after `react-0.13`, if you are using older version, you will have to create a component by your own and add the [I13nMixin](#13n-mixin).
-
-```js
-var createI13nNode = require('react-i13n').createI13nNode;
-var I13nDiv = createI13nNode('div', {
-    isLeafNode: false,
-    bindClickEvent: false,
-    follow: false
-});
-
-<I13nDiv i13nModel={parentI13nModel}>
-    // the i13n node inside will inherit the model data of its parent
-</I13nDiv>
-```
-
-For common usage, we define some components with specific setting, we can require them without generating them every time. These setting can be overwritten by `props`.
-
-| Component | isLeafNode | bindClickEvent | follow |
-| --------- | ---------- | -------------- | -------- |
-| **I13nAnchor** | true | true | true |
-| **I13nButton** | true | true | true |
-| **I13nDiv** | false | false | false |
-
-
-### Fire events
-`react-i13n` automatically fire `click` and `updated` events, you can also fire other events via `reactI13n.execute`, just make sure you have proper event handler implemented.
-* `eventName` - the event name
-* `payload` - the payload object you want to pass into the event handler
-* `callback` - the callback function after event is executed
-
-```js
-var ReactI13n = require('react-i13n').ReactI13n;
-ReactI13n.getInstance().execute('pageview', {payload}, function callback () {
-    // 
-});
 ```
 
 ## Test
 
 ### Unit
 
-`grunt unit`
+* `grunt unit` to run simply unit test
+* `grunt cover` to generate the coverage report
 
 ### Functional
 

--- a/docs/api/I13nNode.md
+++ b/docs/api/I13nNode.md
@@ -1,0 +1,56 @@
+## I13nNode
+The `I13nNode` class used to create an `I13nTree`, you will need this if you are implementing a plugin, we provide APIs for you to build the functionalities you want with the plugin.
+
+### Constructor(parentNode, model, isLeafNode, isViewportEnabled)
+ * `parentNode` - parent node
+ * `model` - custom model values
+ * `isLeafNode` - indicate if it's a link node
+ * `isViewportEnabled` - indicate if viewport check enable
+
+### appendChildNode(I13nNode)
+Append an i13n node.
+
+### getChildrenNodes()
+Get the children nodes array.
+
+### getCustomAttribute(key)
+Get the custom value.
+
+### getDOMNode()
+Get the DOMNode set by `setDOMNode`.
+
+### getMergedModel()
+Get the model data which is traversed and combined to the root.
+
+### getModel()
+Get the i13nModel data of this i13n node.
+
+### getPosition()
+Get the position of its parent.
+
+### getText(target)
+Get the inner text value of DOMNode related to this i13n node set by `setDOMNode`. You can pass a DOMObject, getText will try to get target's text first then fallback to the related DOMObject, it's used for some case like click event, you want to get the text of real click target, instead of the DOMObject that we hook the click event.
+
+### isInViewport()
+Get if the i13nNode is in the viewport, if you don'y enable the viewport checking, it will always return true.
+
+### isLeafNode()
+Get the flag indicates if the node is a leaf node.
+
+### isOrderDirty()
+If the children nodes are already sorted, we will mark this flag as false, which means next time when we try to execute the action related to the order, e.g., `getPosition()`, we don't need to sort them again. This flag will be set as true if it has any child appended or removed.
+
+### removeChildNode(I13nNode)
+Remove the i13n node.
+
+### setCustomAttribute(key, value)
+Set the custom attribute you want, it used for some cases if you want to record some status, e.g., already traversed and you don't want to do the action again.
+
+### setDOMNode(DOMObject)
+Set the DOMObject related to this I13Node.
+
+### sortChildrenNode()
+Sort the children nodes, this will automatically executed when you try to `getPosition`, which means for most case you will not need to do this manaully.
+
+### traverseNodes(handler)
+Will traverse the all the children under this node and execute the handler function passing with the child node.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,5 @@
+### APIs
+
+ * [setupI13n](./setupI13n.md) - higher order function for us to complete app level `react-i13n` setting
+ * [createI13nNode](./createI13nNode.md) - higher order function for us to create `i13nNode`
+ * [I13nNode](./I13nNode.md) - class of I13nNode, you will need this to implement the plugin

--- a/docs/api/createI13nNode.md
+++ b/docs/api/createI13nNode.md
@@ -1,0 +1,51 @@
+## I13n Component
+If the component has the i13n functionalities, we will mirror an `I13nNode` in `I13nTree` for that component, we provide two ways for you to generate an `I13nComponent`. You can use following `props` to set what we want the `I13nComponetn` act like.
+
+ * `i13nModel` - the i13nModel data object or a dynamic function returns the data object.
+ * `isLeafNode` - define if it's a leaf node or not, we will fire `created` event for every node when it's created, `isLeafNode` will help us to know if you want to do the action. e.g, you might only want to send out beacons to record links. 
+ * `bindClickEvent` - define if want to bind a click handler or not.
+ * `follow` - define if click handler need to redirect users to destination after sending beacon or not. You could set `follow=false` and the handler would send out beacon but will not redirect users.
+ * you can pass all the `props` you need for the original component, we will pass them to the component.
+
+### createI13nNode(component, options)
+The `high order function` which integrate `I13nMixin`, it return a compoment with all I13n functionalities.
+ * `component` - can be a string for native tags e.g., `a`, `button` or a react component you create
+ * `options` - options object, it would be the default `props` of that I13nNode, you can also pass options with `props` to overwrite it.
+
+For example, if you want to track the links, you will need to create anchor with `createI13nNode` and enable the click tracking.
+
+```js
+var createI13nNode = require('react-i13n').createI13nNode;
+var I13nAnchor = createI13nNode('a', {
+    isLeafNode: true,
+    bindClickEvent: true,
+    follow: true
+});
+
+<I13nAnchor i13nModel={i13nModel}>
+    ...
+</I13nAnchor>
+```
+
+### I13nMixin
+Everything is done by the `i13nMixin`, which means you can add the `I13nMixin` into the component directly to give the component i13n functionalities.
+
+```js
+var I13nMixin = require('react-i13n').I13nMixin;
+var Foo = React.createClass({
+    mixins: [I13nMixin],
+    // you can set the default props or pass them as props when you are using Foo
+    getDefaultProps: {
+        isLeafNode: false,
+        bindClickEvent: false,
+        follow: false
+    }
+    ...
+});
+
+// in template
+<Foo i13nModel={i13nModel}>
+    // will create a i13n node for Foo
+    ...
+</Foo>
+```

--- a/docs/api/setupI13n.md
+++ b/docs/api/setupI13n.md
@@ -1,0 +1,26 @@
+## setupI13n
+
+We provide `setupI13n` as a convenient `higher order function` to setup the ReactI13n, you will need to pass your `top level component`, `options`, and `plugins` into. It takes care of creating a `ReactI13n` instance and setup the plugins. Just use the function to create a component then render it.
+
+ * `Component` - the top level component.
+ * `options` - the options passed into ReactI13n.
+ * `options.rootModelData` - define the `i13nModel` data of the root.
+ * `options.I13nNodeClass` - you can inherit the `I13nNode` and add the functionality you need, just pass the class.
+ * `options.isViewportEnabled` - define if you want to enable the viewport checking.
+ * `plugins` - plugins array that you defined according to the definition below.
+
+```js
+var React = require('react/addons');
+var setupI13n = require('react-i13n').setupI13n;
+var someReactI13nPlugin = require('some-react-i13n-plugin');
+
+var DemoApp = React.createClass({
+    ...
+});
+
+var I13nDempApp = setupI13n(DemoApp, {
+    rootModelData: {site: 'foo'}, // the default i13n model apply to the root
+    isViewportEnabled: true
+}, [someReactI13nPlugin]);
+// then you could use I13nDemoApp to render you app
+```

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,6 @@
+### Guides
+
+ * [create plugins](./createPlugins.md) - guideline about how to create a plugin.
+ * [event system](./eventSystem.md) - introduce how we utilize the event system.
+ * [integrate with components](./integrateWithComponents.md) - introduce how we manage i13n data, integrate with components and take the benefit of `react-i13n`.
+ * [main ideas](./mainIdeas.md) - the ideas and the implementation details.

--- a/docs/guides/createPlugins.md
+++ b/docs/guides/createPlugins.md
@@ -1,0 +1,33 @@
+## Implement the plugin.
+A valid plugin must contains
+ * `name` - the plugin name
+ * `eventHandlers` - handlers functions for the events, typically in the eventHandler function we would send out a tracking beacon, now `react-i13n` has `click`, `created` and `enterViewport`, you can define the events you need and implement the handlers function, e.g., `pageview`.
+
+All the `eventHandlers` will receive a `payload` object and a `callback` function. By default in payload you will get:
+ * `payload.I13nNode` - the I13n node related to the event, then you could use the APIs provided by [I13nNode](../api/I13nNode.md) to get the information you need. It's typically used for default events e.g., `click`, `created`, `enterViewport`. For custom events, if you don't pass `I13nNode`, it will default be the `root I13n Node`.
+ * `payload.env` - `server` or `client`, some events e.g., `pageview` will fire on both server and client side, you can define the prefer way you want to handle the beacon.
+
+```js
+var ReactI13n = require('react-i13n').ReactI13n;
+// define the plugin
+var gaPlugin = {
+    name: 'ga',
+    eventHandlers: {
+        click: function (payload, callback) {
+            // click handlers
+        },
+        pageview: function (payload, callback) {
+            if ('client' === payload.env) {
+                // client side pageview handlers
+            } else {
+                // server side pageview handlers
+            }
+        },
+        created: function (payload, callback) {
+            // created handlers
+        }
+    }
+};
+
+```
+Then we can plug the `plugin` with [setupI13n](../api/setupI13n.md).

--- a/docs/guides/eventSystem.md
+++ b/docs/guides/eventSystem.md
@@ -1,0 +1,45 @@
+## Event System
+
+`react-i13n` communicate with `plugins` using it's own `event system`, which provides the ability for `react-i13n` to control and communicate with multiple plugin at the same time. It helps `react-i13n` to make
+
+In other words, whenever you request plugins to take actions, you will need to fire the event instead of accessing the instrumentation library directly.
+
+### Default Events
+By default, `react-i13n` will fire following events:
+ * `click` - happens when user click a `I13nNode` with `clickHandler`
+ * `created` - happens when the `I13nComponent` is created
+ * `enterViewport` - happens when the `isViewportEnabled` is true and the node enter the viewport
+
+### reactI13n.execute(eventName, payload, callback)
+Other than the default events, you can define the `eventHandlers` yourself and use `[$reactI13nInstance].execute` to execute that.
+ * `eventName` - the event name
+ * `payload` - the payload object you want to pass into the event handler
+ * `callback` - the callback function after event is executed
+
+```js
+var React = require('react/addons');
+var ReactI13n = require('react-i13n').ReactI13n;
+var fooPlugin = {
+    name: 'foo', 
+    eventHandlers: {
+        customEvent: function (payload, callback) {
+            // handle the event here, typically you will use some beacon function to fire beacon
+            callback();
+        }
+        ...
+    }
+}
+
+var Foo = React.createClass({
+    componentWillMount: function () {
+        // whenever you define a event handler, you can fire a event for that.
+        ReactI13n.getInstance().execute('customEvent', {payload}, function beaconCallback () {
+            // do whatever after beaconing
+        });
+    }
+    ...
+});
+
+var I13nFoo = setupI13n(Foo, {}, [fooPlugin]);
+
+```


### PR DESCRIPTION
@redonkulus update README, move api and guides into `docs` folder, keeping the main README clear.

The api and guild can be used to be included into other introduction article. 
