### PR TITLE
fix peer dep for npm@1 using <0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "instrumentation"
   ],
   "peerDependencies": {
-    "react": "<= 0.13.x"
+    "react": "<0.14.0"
   },
   "precommit": [
     "lint",


### PR DESCRIPTION
tried and this might helps to fix the peerDependencies issue with `npm@1.x` , 

tested with fluxible.io/yahoodotcom looks fine, 


then we can remove the allow_failure and trubole shooting document https://github.com/yahoo/fluxible.io/pull/130