### PR TITLE
provide clearer debug msg, shows inherit or not for each model data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Since the i13n data is defined at each level. Whenever you want to get the `i13n
 ## Presentation
 Take a look at [Rafael Martins' slides](http://www.slideshare.net/RafaelMartins21/instrumentation-talk-39547608) from a recent React meetup to understand more.
 
+## Debugging
+Add `i13n_debug=1` to the request url, you will get the i13n model for each `i13n node` directly shown on the page. It shows the information for each model data and where the data inherits from.
 
 ## Testing
 

--- a/src/libs/I13nNode.js
+++ b/src/libs/I13nNode.js
@@ -88,30 +88,47 @@ I13nNode.prototype.getDOMNode = function getDOMNode () {
 /**
  * Get merged model which is traced to the root 
  * @method getMergedModel
+ * @param {Boolean} debugMode indicate it's debug mode, will return additional information for debug tool
  * @return {Object} the merged model
  */
-I13nNode.prototype.getMergedModel = function getMergedModel () {
+I13nNode.prototype.getMergedModel = function getMergedModel (debugMode) {
     if (this._parentNode) {
-        var parentModel = this._parentNode.getMergedModel();
-        return objectAssign({}, parentModel, this.getModel());
+        var parentModel = this._parentNode.getMergedModel(debugMode);
+        return objectAssign({}, parentModel, this.getModel(debugMode));
     } else {
-        return this.getModel();
+        return this.getModel(debugMode);
     }
 };
 
 /**
  * Get plain model object, from either dynamic function or plain object
  * @method getModel
+ * @param {Boolean} debugMode indicate it's debug mode, will return additional information for debug tool
  * @return {Object} the plain object model
  */
-I13nNode.prototype.getModel = function getModel () {
+I13nNode.prototype.getModel = function getModel (debugMode) {
+    var self = this;
     var model = null;
-    if ('function' === typeof this._model) {
-        model = this._model();
+    var finalModel = null;
+    if ('function' === typeof self._model) {
+        model = self._model();
     } else {
-        model = this._model;
+        model = self._model;
     }
-    return objectAssign({}, model); // always return new object to prevent reference issue
+    
+    //always return new object to prevent reference issue
+    finalModel = objectAssign({}, model);
+
+    if (debugMode) {
+        // add the DOMNode to the returned model, so that it can be used in debug tool
+        Object.keys(finalModel).forEach(function interateModel(index) {
+            finalModel[index] = {
+                value: finalModel[index],
+                DOMNode: self.getDOMNode()
+            };
+        });
+    }
+    return finalModel;
 };
 
 /**

--- a/src/libs/ReactI13n.js
+++ b/src/libs/ReactI13n.js
@@ -2,7 +2,7 @@
  * Copyright 2015, Yahoo Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-/* global window, global */
+/* global window, global, document */
 'use strict';
 
 var debugLib = require('debug');
@@ -60,6 +60,9 @@ ReactI13n.getInstance = function getInstance () {
 ReactI13n.prototype.createRootI13nNode = function createRootI13nNode () {
     var I13nNodeClass = this.getI13nNodeClass();
     GLOBAL_OBJECT.rootI13nNode = new I13nNodeClass(null, this._rootModelData, false);
+    if ('client' === ENVIRONMENT) {
+        GLOBAL_OBJECT.rootI13nNode.setDOMNode(document.body);
+    }
     return GLOBAL_OBJECT.rootI13nNode;
 };
 

--- a/tests/functional/i13n-functional.jsx
+++ b/tests/functional/i13n-functional.jsx
@@ -67,7 +67,7 @@ var I13nComponentLevel1 = React.createClass({
                     <div>
                         <I13nDiv className="NestTestI13nComponentLevel2" i13nModel={{vl2:'bar'}}>
                             <div>
-                                <I13nAnchor className="NestTestI13nComponentLevel3" follow={false} i13nModel={{vl3:'baz', vl3_ovr:'baz'}}>NestTestI13nComponentLevel3</I13nAnchor>
+                                <I13nAnchor href="./mock-destination-page.html" className="NestTestI13nComponentLevel3" follow={false} i13nModel={{vl3:'baz', vl3_ovr:'baz'}}>NestTestI13nComponentLevel3</I13nAnchor>
                             </div>
                         </I13nDiv>
                     </div>


### PR DESCRIPTION
#9 
For debug tool, we can provide clearer information for users, 
after the modification, we can see clearer massage on the debug tool, it shows where the data inherit from whenever mouseover. 

@redonkulus @lingyan 

1. when we call getModel, add one param `debugModel`, if it's true, return the `DOMNode` as well
2. hook mouse event for each model item, when mouse over, highlight the `DOMNode` so that users can know where the data from. 
3. add debug information in README.

for example, when we mouse over to the inherited model, it highlight the entire stream model, where the data inherited from. 
![2015-06-03 11 40 47 pm](https://cloud.githubusercontent.com/assets/3829183/7978427/19df97a2-0a4a-11e5-9308-d605a06e89bf.png)
