### PR TITLE
support auto scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Typically, you have to manually add instrumentation code throughout your applica
 * **Performant** - Tracking data (`i13nModel`) can be a plain JS object or custom function. This means you can [dynamically change tracking data](./docs/guides/integrateWithComponents.md#dynamic-i13n-model) without causing unnecessary re-renders.
 * **Adaptable** - If you are using an isomorphic framework (e.g. [Fluxible](http://fluxible.io)) to build your app, you can easily [change the tracking implementation](./docs/guides/createPlugins.md) on the server and client side. For example, to track page views, you can fire an http request on server and xhr request on the client.
 * **Optimizable** - We provide an option to enable viewport checking for each `I13nNode`. Which means that data will only be beaconed when the node is in the viewport. This reduces the network usage for the user and provides better tracking details.
+* **Auto Scan Links** - Support [auto scan links](./docs/api/createI13nNode.md) for the cases you are not able to replace the component you are using to get it tracked, e.g., if you have dependencies or you are using `dangerouslySetInnerHTML`. We scan the tags you define on client side, track them and build nodes for them in i13n tree.
 
 ## Install
 

--- a/docs/api/createI13nNode.md
+++ b/docs/api/createI13nNode.md
@@ -6,6 +6,9 @@ If your component needs i13n functionality, we will mirror an `I13nNode` in `I13
  * `isLeafNode` - define if it's a leaf node or not, we will fire `created` event for every node when it's created, `isLeafNode` will help us to know if you want to do the action. e.g, you might only want to send out beacons to record links. 
  * `bindClickEvent` - define if want to bind a click handler or not.
  * `follow` - define if click handler need to redirect users to destination after sending beacon or not. You could set `follow=false` and the handler would send out beacon but will not redirect users.
+ * `scanLinks` - other than replacing all links component, we provide a options to do that automatically, please note that this should be only used for some case you cannot replace the component, e.g., you are using `dangerouslySetInnerHTML` or the component has the dependencies of other projects. 
+ * `scanLinks.enable` - enable the auto links-scanning procedure.
+ * `scanLinks.tags` - an array to define the tags you want it be be scanned, default to be `['a', 'button']`.
  * you can pass all the `props` you need for the original component, we will pass them to the component.
 
 ### createI13nNode(component, options)
@@ -28,6 +31,30 @@ var I13nAnchor = createI13nNode('a', {
     ...
 </I13nAnchor>
 ```
+
+If you have a use case where you cannot replace the links with `I13n Component`, i.e, when using `dangerouslySetInnerHTML`. You can integrate the `scanLinks` options to automatically track these links. This option should be used sparingly since it can create additional DOM manipulations. 
+
+```js
+var createI13nNode = require('react-i13n').createI13nNode;
+var I13nDiv = createI13nNode('div', {
+    isLeafNode: false,
+    bindClickEvent: false,
+    follow: false,
+    scanLinks: {
+        enable: true,
+        tags: ['a', 'button']
+    }
+});
+
+<I13nDiv i13nModel={i13nModel}>
+    // the links inside will be scanned and tracked
+    // the i13n data will apply the i13nModel from I13nDiv
+    <a href="/foo">foo</a>
+    <button>bar</button>
+</I13nDiv>
+```
+
+
 
 ### I13nMixin
 Everything is done by the `i13nMixin`, which means you can add the `I13nMixin` into the component directly to give the component i13n functionality.

--- a/src/libs/I13nNode.js
+++ b/src/libs/I13nNode.js
@@ -167,8 +167,8 @@ I13nNode.prototype.getText = function getText (target) {
     if (!DOMNode && !target) {
         return '';
     }
-    var text = (DOMNode && (DOMNode.value || DOMNode.innerHTML)) ||
-        (target && (target.value || target.innerHTML));
+    var text = (target && (target.value || target.innerHTML)) || 
+        (DOMNode && (DOMNode.value || DOMNode.innerHTML));
     if (text) {
         text = text.replace(TAG_PATTERN, '');
     }

--- a/src/mixins/viewport/ViewportMixin.js
+++ b/src/mixins/viewport/ViewportMixin.js
@@ -32,14 +32,14 @@ var Viewport = {
 
     exitViewportCallback: null,
 
-    _detectViewport: function () {
-        var self = this;
-        var DOMNode = self.getDOMNode();
-        if (!self.isMounted() || !DOMNode) {
+    _detectElement: function (i13nNode, enterViewportCallback, exitViewportCallback) {
+        
+        var element = i13nNode && i13nNode.getDOMNode();
+        if (!element) {
             return;
         }
-        var rect = DOMNode.getBoundingClientRect();
-        var viewportMargins = self.props.viewport.margins;
+        var rect = element.getBoundingClientRect();
+        var viewportMargins = this.props.viewport.margins;
         var margins;
         if (viewportMargins.usePercent) {
             margins = {
@@ -49,18 +49,28 @@ var Viewport = {
         } else {
             margins = viewportMargins;
         }
+        
         // Detect Screen Bottom                           // Detect Screen Top
         if ((rect.top < window.innerHeight + margins.top) && (rect.bottom > 0  - margins.bottom)) {
-            if (!self.isOnViewport) {
-                self.enterViewportCallback && self.enterViewportCallback();
-                self.isOnViewport = true;
+            if (!i13nNode.isInViewport()) {
+                enterViewportCallback && enterViewportCallback();
+                i13nNode.setIsInViewport(true);
             }
         } else {
-            if (self.isOnViewport) {
-                self.exitViewportCallback && self.exitViewportCallback();
-                self.isOnViewport = false;
+            if (i13nNode.isInViewport()) {
+                exitViewportCallback && exitViewportCallback();
+                i13nNode.setIsInViewport(false);
             }
         }
+    },
+
+    _detectViewport: function () {
+        var self = this;
+        if (!self.isMounted()) {
+            return;
+        }
+        self._detectElement(self._i13nNode, self.enterViewportCallback, self.exitViewportCallback);
+        self._subComponentsViewportDetection && self._subComponentsViewportDetection();
     },
 
     _detectHidden: function (hidden) {

--- a/tests/functional/i13n-functional.jsx
+++ b/tests/functional/i13n-functional.jsx
@@ -72,6 +72,9 @@ var I13nComponentLevel1 = React.createClass({
                         </I13nDiv>
                     </div>
                 </I13nDiv>
+                <I13nDiv i13nModel={{sec: 'auto-scan'}} scanLinks={{enable: true}}>
+                    <a className="AutoScanLink" href="/mock-destination-page.html" target="_blank">AutoScanLink</a>
+                </I13nDiv>
             </div>
         );
     }

--- a/tests/functional/i13n.spec.js
+++ b/tests/functional/i13n.spec.js
@@ -74,10 +74,20 @@ describe('React I13n test', function () {
         link.click();
         var events = window.firedEvents;
         var currentEventCount = events.length;
-        var currentEventCount = events.length;
         expect(events[currentEventCount - 1].name).to.eql('click');
         expect(events[currentEventCount - 1].model).to.eql({page: 'test-page', sec:'foo'});
         expect(events[currentEventCount - 1].text).to.eql('NormalLinkWithTargetBlank');
         expect(events[currentEventCount - 1].position).to.eql(4);
+    });
+    
+    it('should fire a click for the auto-scanned links', function () {
+        var link = document.querySelectorAll('.AutoScanLink')[0];
+        link.click();
+        var events = window.firedEvents;
+        var currentEventCount = events.length;
+        expect(events[currentEventCount - 1].name).to.eql('click');
+        expect(events[currentEventCount - 1].model).to.eql({page: 'test-page', sec:'auto-scan'});
+        expect(events[currentEventCount - 1].text).to.eql('AutoScanLink');
+        expect(events[currentEventCount - 1].position).to.eql(1);
     });
 });


### PR DESCRIPTION
#8 
@redonkulus @lingyan 

support auto scan to track links, it's `not a recommend way` but sometime users will need that, for example when they are using `dangerouslySetInnerHTML`, they cannot change `<a>` to `<I13nAnchor>`, they will need this, we will scan tags with `componentDidMount` by `getElementsByTagName`, and 
* create i13nNode
* setup viewport detection
* add debug dashboard 
for each scanned links

## Usage
add `scanLinks` as props in I13nComponent, 

```
<I13nDiv i13nModel={i13nModel} scanLinks={{enable:true, tags:['a', 'button']}}>
    // the links inside will be scanned and tracked
    // the i13n data will apply the i13nModel from I13nDiv
    <a href="/foo">foo</a>
    <button>bar</button>
</I13nDiv>
```

