### PR TITLE
add I13nUtils mixin / add setParentNode in I13nNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Typically, you have to manually add instrumentation code throughout your applica
 ## Features
 
 * **i13n tree** - Automated [instrumentation tree](#i13n-tree) creation that mirrors your applications React component hierarchy.
-* **React integration** - Provides a [createI13nNode](./docs/api/createI13nNode.md#createi13nnodecomponent-options) component and [I13nMixin](./docs/api/createI13nNode.md#i13nmixin) that easily integrate with your application.
+* **React integration** - Provides a [createI13nNode](./docs/api/createI13nNode.md#createi13nnodecomponent-options) component that easily integrate with your application.
 * **Pluggable** - A pluggable interface lets you integrate any data analytics library (i.e. Google Analytics, Segment, etc). Take a look at the [available plugins](#available-plugins).
 * **Performant** - Tracking data (`i13nModel`) can be a plain JS object or custom function. This means you can [dynamically change tracking data](./docs/guides/integrateWithComponents.md#dynamic-i13n-model) without causing unnecessary re-renders.
 * **Adaptable** - If you are using an isomorphic framework (e.g. [Fluxible](http://fluxible.io)) to build your app, you can easily [change the tracking implementation](./docs/guides/createPlugins.md) on the server and client side. For example, to track page views, you can fire an http request on server and xhr request on the client.
@@ -48,7 +48,7 @@ var I13nAnchor = createI13nNode('a', {
 
 var DemoApp = React.createClass({
     componentWillMount: function () {
-        ReactI13n.getInstance().execute('pageview', {}); // fire a custom event
+        this.props.i13n.executeEvent('pageview', {}); // fire a custom event
     },
     render: function () {
         ...

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -3,3 +3,4 @@
  * [setupI13n](./setupI13n.md) - higher order component that wraps your application to setup `react-i13n` settings
  * [createI13nNode](./createI13nNode.md) - higher order component to create an [I13nNode](./I13nNode.md)
  * [I13nNode](./I13nNode.md) - class of I13nNode, you will need this to implement the plugin
+ * [I13nUtils](./I13nUtils.md) - mixin provides util functions for you to access the i13n nodes and execute i13n functionalities

--- a/docs/api/createI13nNode.md
+++ b/docs/api/createI13nNode.md
@@ -12,7 +12,7 @@ If your component needs i13n functionality, we will mirror an `I13nNode` in `I13
  * you can pass all the `props` you need for the original component, we will pass them to the component.
 
 ### createI13nNode(component, options)
-The `high order component` which integrates the `I13nMixin`, it will return a compoment with full I13n functionality.
+The `high order component` integrates the functionalities of i13n, it returns a decorated component with full I13n functionality.
 
  * `component` - can be a string for native tags e.g., `a`, `button` or a react component you create
  * `options` - options object, it would be the default `props` of that I13nNode, you can also pass options with `props` to overwrite it.
@@ -54,27 +54,6 @@ var I13nDiv = createI13nNode('div', {
 </I13nDiv>
 ```
 
+### Utils Functions
 
-
-### I13nMixin
-Everything is done by the `i13nMixin`, which means you can add the `I13nMixin` into the component directly to give the component i13n functionality.
-
-```js
-var I13nMixin = require('react-i13n').I13nMixin;
-var Foo = React.createClass({
-    mixins: [I13nMixin],
-    // you can set the default props or pass them as props when you are using Foo
-    getDefaultProps: {
-        isLeafNode: false,
-        bindClickEvent: false,
-        follow: false
-    }
-    ...
-});
-
-// in template
-<Foo i13nModel={i13nModel}>
-    // will create a i13n node for Foo
-    ...
-</Foo>
-```
+You will get i13n util functions automatically via `this.props.i13n` by using `createI13nNode`, more detail please refer to [util functions](../guide/utilFunctions.md).

--- a/docs/api/setupI13n.md
+++ b/docs/api/setupI13n.md
@@ -27,3 +27,7 @@ var I13nDempApp = setupI13n(DemoApp, {
 
 // then you could use I13nDemoApp to render you app
 ```
+
+### Util Functions
+
+You will get i13n util functions automatically via `this.props.i13n` by using `setupI13n`, more detail please refer to [util functions](../guide/utilFunctions.md).

--- a/docs/guides/eventSystem.md
+++ b/docs/guides/eventSystem.md
@@ -8,8 +8,8 @@ By default, `react-i13n` will fire the following events:
  * `created` - happens when the `I13nComponent` is created
  * `enterViewport` - happens when the `isViewportEnabled` is true and the node enters the viewport
 
-### reactI13n.execute(eventName, payload, callback)
-Other than the default events, you can define the `eventHandlers` yourself and use `[$reactI13nInstance].execute` to execute that.
+### executeI13nEvents(eventName, payload, callback)
+Other than the default events, you can define the `eventHandlers` yourself and use `executeI13nEvents` (provided by [I13nUtils](../api/I13nUtils.md)) to execute that.
  * `eventName` - the event name
  * `payload` - the payload object you want to pass into the event handler
  * `callback` - the callback function after event is executed
@@ -17,8 +17,9 @@ Other than the default events, you can define the `eventHandlers` yourself and u
 ```js
 var React = require('react');
 var ReactI13n = require('react-i13n').ReactI13n;
+var I13nUtils = require('react-i13n').I13nUtils;
 var fooPlugin = {
-    name: 'foo', 
+    name: 'foo',
     eventHandlers: {
         customEvent: function (payload, callback) {
             // handle the event here, typically you will use some beacon function to fire the beacon
@@ -29,9 +30,10 @@ var fooPlugin = {
 }
 
 var Foo = React.createClass({
+    mixins: [I13nUtils],
     componentWillMount: function () {
         // whenever you define a event handler, you can fire an event for that.
-        ReactI13n.getInstance().execute('customEvent', {payload}, function beaconCallback () {
+        this.executeI13nEvent('customEvent', {payload}, function beaconCallback () {
             // do whatever after beaconing
         });
     }
@@ -41,3 +43,4 @@ var Foo = React.createClass({
 var I13nFoo = setupI13n(Foo, {}, [fooPlugin]);
 
 ```
+

--- a/docs/guides/utilFunctions.md
+++ b/docs/guides/utilFunctions.md
@@ -1,0 +1,56 @@
+## Util Functions
+
+We provides util functions for you to easily access the resource provided by `react-i13n`, you have two options to get the util functions, 
+
+* `props` - When you are using [setupI13n](../api/setupI13n.md) or [createI13nNode](../api/createI13nNode.md), we will automatically pass util functions via `this.props.i13n`.
+* `context` - You can always define `contextTypes` and access util functions via `context`, i.e., `this.context.i13n`.
+
+```js
+// with setupI13n or createI13nNode, you will automatically get this.props.i13n for i13n util functions
+var DemoComponent = React.createClass({
+    displayName: 'DemoComponent',
+    render: function() {
+        // this.props.i13n.getI13nNode() to access the i13nNode created by createI13nNode
+        // this.props.i13n.executeEvent() to execute i13n event
+    }
+});
+
+var I13nDemoComponent = createI13nNode(DemoComponent);
+```
+
+```js
+
+// For components without `setupI13n` and `createI13nNode`, you can still get i13n functions via context
+var DemoComponent = React.createClass({
+    displayName: 'DemoComponent',
+    contextTypes: {
+        i13n: React.PropTypes.object
+    }
+    render: function() {
+        // this.context.i13n.getI13nNode() to access the nearest i13nNode created by createI13nNode
+        // this.context.i13n.executeEvent() to execute i13n event
+    }
+});
+
+```
+
+### getI13nNode()
+get the nearest `i13nNode` created by `createI13nNode`
+
+### executeEvent(eventName, payload, callback)
+execute the i13n event, so that you don't need to call `ReactI13n.getInstnace().execute`, it also get the i13nNode and add into payload for you
+
+```js
+var DemoComponent = React.createClass({
+    displayName: 'DemoComponent',
+    componentDidMount: function () {
+        // executeEvent will find the i13nNode and append to the payload for you, which means the final payload will be the i13nNode plus the payload you defined,
+        // i.e., {i13nNode: [theI13nNode], foo: 'bar'}
+        this.props.i13n.executeEvent('someEventName', {foo: 'bar'}, function callback() {
+            // callback
+        });
+    }
+});
+
+var I13nDemoComponent = createI13nNode(DemoComponent);
+```

--- a/src/libs/I13nNode.js
+++ b/src/libs/I13nNode.js
@@ -255,6 +255,15 @@ I13nNode.prototype.setCustomAttribute = function setCustomAttribute (name, value
 };
 
 /**
+ * Set the parent node, this method provide you the ability to update I13n Tree dynamically
+ * @method setParentNode
+ * @param {Object} parentNode the parent node
+ */
+I13nNode.prototype.setParentNode = function setParentNode (parentNode) {
+    this._parentNode = parentNode;
+};
+
+/**
  * Sort children according to the position in the page
  * @method sortChildrenNodes
  * @param {Boolean} propagate indicate if want to propagate the sorting event to its parent

--- a/src/mixins/I13nUtils.js
+++ b/src/mixins/I13nUtils.js
@@ -1,0 +1,93 @@
+var React = require('react');
+var ReactI13n = require('../libs/ReactI13n');
+
+/**
+ * React.js I13n Utils Mixin
+ * Provide functions for components to access the i13nNode
+ * @class I13nUtils
+ */
+var I13nUtils = {
+
+    contextTypes: {
+        i13n: React.PropTypes.shape({
+            executeEvent: React.PropTypes.func,
+            getI13nNode: React.PropTypes.func,
+            parentI13nNode: React.PropTypes.object
+        })
+    },
+    
+    childContextTypes: {
+        i13n: React.PropTypes.shape({
+            executeEvent: React.PropTypes.func,
+            getI13nNode: React.PropTypes.func,
+            parentI13nNode: React.PropTypes.object
+        })
+    },
+    
+    /**
+     * getChildContext
+     * @method getChildContext
+     */
+    getChildContext: function () {
+        return {
+            i13n: {
+                executeEvent: this.executeI13nEvent,
+                getI13nNode: this.getI13nNode,
+                parentI13nNode: this._i13nNode
+            }
+        };
+    },
+
+    /**
+     * execute the i13n event
+     * @method executeI13nEvent
+     * @param {String} eventName event name
+     * @param {Object} payload payload object
+     * @param {Function} callback function
+     * @async
+     */
+    executeI13nEvent: function (eventName, payload, callback) {
+        var reactI13nInstance = this._getReactI13n();
+        payload = payload || {};
+        payload.i13nNode = payload.i13nNode || this.getI13nNode();
+        if (reactI13nInstance) {
+            reactI13nInstance.execute(eventName, payload, callback);
+        } else {
+            callback && callback();
+        }
+    },
+
+    /**
+     * Get the nearest i13n node from the parent, default will go to the rootI13nNode
+     * @method getI13nNode
+     * @return {Object} i13n node
+     */
+    getI13nNode: function () {
+        return this._i13nNode || this._getParentI13nNode();
+    },
+
+    /**
+     * get React I13n instance
+     * @method _getReactI13n
+     * @private
+     * @return {Object} react i13n instance
+     */
+    _getReactI13n: function () {
+        return ReactI13n.getInstance();
+    },
+
+    /**
+     * _getParentI13nNode, defualt will go to the rootI13nNode
+     * @method _getParentI13nNode
+     * @private
+     * @return {Object} parent i13n node
+     */
+    _getParentI13nNode: function () {
+        // https://twitter.com/andreypopp/status/578974316483608576, get the context from parent context
+        // TODO remove this at react 0.14
+        var context = (this._reactInternalInstance && this._reactInternalInstance._context) || this.context;
+        return (context && context.i13n && context.i13n.parentI13nNode) || this._getReactI13n().getRootI13nNode();
+    }
+}
+
+module.exports = I13nUtils;

--- a/src/utils/clickHandler.js
+++ b/src/utils/clickHandler.js
@@ -58,7 +58,7 @@ module.exports = function clickHandler (e) {
     var href = '';
 
     // return and do nothing if the handler is append on a component without I13nMixin
-    if (!self._executeI13nEvent) {
+    if (!self.executeI13nEvent) {
         return;
     }
 
@@ -91,7 +91,7 @@ module.exports = function clickHandler (e) {
         }
     }
 
-    self._executeI13nEvent('click', {i13nNode: self._i13nNode, e:e}, function clickBeaconCallback () {
+    self.executeI13nEvent('click', {i13nNode: self.getI13nNode(), e:e}, function clickBeaconCallback () {
         if (isRedirectLink) {
             if (isFormSubmit(target)) {
                 // if the button has no form linked, then do nothing

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -49,7 +49,12 @@ module.exports = function createI13nNode (Component, options) {
          * @method render
          */
         render: function () {
-            var props = objectAssign({}, this.props);
+            var props = objectAssign({}, {
+                i13n: {
+                    executeEvent: this.executeI13nEvent,
+                    getI13nNode: this.getI13nNode
+                }
+            }, this.props);
 
             // delete the props that only used in this level
             try {

--- a/src/utils/setupI13n.js
+++ b/src/utils/setupI13n.js
@@ -6,6 +6,8 @@
 
 var React = require('react');
 var ReactI13n = require('../libs/ReactI13n');
+var I13nUtils = require('../mixins/I13nUtils');
+var objectAssign = require('object-assign');
 
 /**
  * Create an app level component with i13n setup
@@ -28,6 +30,8 @@ module.exports = function setupI13n (Component, options, plugins) {
 
     RootI13nComponent = React.createClass({
 
+        mixins: [I13nUtils],
+
         displayName: 'RootI13n' + componentName,
     
         /**
@@ -40,10 +44,16 @@ module.exports = function setupI13n (Component, options, plugins) {
         },
 
         render: function () {
+            var props = objectAssign({}, {
+                i13n: {
+                    executeEvent: this.executeI13nEvent,
+                    getI13nNode: this.getI13nNode
+                }
+            }, this.props);
             return React.createElement(
                 Component,
-                this.props,
-                this.props.children
+                props,
+                props.children
             );
         }
     });

--- a/tests/functional/bootstrap.js
+++ b/tests/functional/bootstrap.js
@@ -11,3 +11,4 @@ window.I13nDiv = require('../../dist/components/I13nDiv');
 window.createI13nNode = require('../../dist/utils/createI13nNode');
 window.clickHandler = require('../../dist/utils/clickHandler');
 window.setupI13n = require('../../dist/utils/setupI13n');
+window.I13nUtils = require('../../dist/mixins/I13nUtils');

--- a/tests/unit/libs/I13nNode.js
+++ b/tests/unit/libs/I13nNode.js
@@ -145,4 +145,19 @@ describe('I13nNode', function () {
         i13nNode.setDOMNode(mockDomNode);
         expect(i13nNode.getText()).to.eql('bar');
     });
+    
+    it('should be able to set the parent node', function () {
+        var model = {
+            sec: 'foo-generated'
+        };
+        var parentModel = {
+            sec: 'foo-parent'
+        };
+        var i13nNode = new I13nNode(null, model, true, true);
+        var parentNode = new I13nNode(null, parentModel, true, true);
+        expect(i13nNode.getMergedModel()).to.eql(model);
+        expect(i13nNode.getParentNode()).to.eql(null);
+        i13nNode.setParentNode(parentNode);
+        expect(i13nNode.getParentNode()).to.eql(parentNode);
+    });
 });

--- a/tests/unit/utils/clickHandler.js
+++ b/tests/unit/utils/clickHandler.js
@@ -48,9 +48,12 @@ describe('clickHandler', function () {
     it('should run click handler correctly', function (done) {
         var i13nNode = new I13nNode(null, {});
         mockClickEvent.preventDefault = function () {};
-        mockComponent._executeI13nEvent = function () {
-            // simply done here to make sure it goes to the _executeI13nEvent
+        mockComponent.executeI13nEvent = function () {
+            // simply done here to make sure it goes to the executeI13nEvent
             done();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -69,8 +72,11 @@ describe('clickHandler', function () {
             expect(executedActions).to.eql(['preventDefault', 'assign']);
             done();
         }
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             callback();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -91,8 +97,11 @@ describe('clickHandler', function () {
                 done();
             }
         }
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             callback();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -114,8 +123,11 @@ describe('clickHandler', function () {
                 done();
             }
         }
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             callback();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -127,9 +139,12 @@ describe('clickHandler', function () {
         mockClickEvent.preventDefault = function () {
             executedActions.push('preventDefault');
         };
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             expect(executedActions).to.eql(['preventDefault']);
             done();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -144,9 +159,12 @@ describe('clickHandler', function () {
         mockClickEvent.preventDefault = function () {
             executedActions.push('preventDefault');
         };
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             expect(executedActions).to.eql([]);
             done();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -162,9 +180,12 @@ describe('clickHandler', function () {
         mockClickEvent.preventDefault = function () {
             executedActions.push('preventDefault');
         };
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             expect(executedActions).to.eql([]);
             done();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
@@ -179,9 +200,12 @@ describe('clickHandler', function () {
         mockClickEvent.preventDefault = function () {
             executedActions.push('preventDefault');
         };
-        mockComponent._executeI13nEvent = function (eventName, payload, callback) {
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
             expect(executedActions).to.eql([]);
             done();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });

--- a/tests/unit/utils/setupI13n.js
+++ b/tests/unit/utils/setupI13n.js
@@ -81,4 +81,26 @@ describe('setupI13n', function () {
         expect(mockData.reactI13n._rootI13nNode).to.be.an('object');
         done();
     });
+    
+    it('should get i13n util functions via both props and context', function (done) {
+        var TestApp = React.createClass({
+            displayName: 'TestApp',
+            contextTypes: {
+                i13n: React.PropTypes.object
+            },
+            render: function() {
+                expect(this.props.i13n).to.be.an('object');
+                expect(this.props.i13n.executeEvent).to.be.a('function');
+                expect(this.props.i13n.getI13nNode).to.be.a('function');
+                expect(this.context.i13n).to.be.an('object');
+                expect(this.context.i13n.executeEvent).to.be.a('function');
+                expect(this.context.i13n.getI13nNode).to.be.a('function');
+                done();
+                return React.createElement('div');
+            }
+        });
+        var I13nTestApp = setupI13n(TestApp, mockData.options, [mockData.plugin]);
+        var container = document.createElement('div');
+        var component = React.render(React.createElement(I13nTestApp, {}), container);
+    });
 });


### PR DESCRIPTION
@redonkulus @lingyan 

provide `i13n utils mixins` for users to have a easier way to access i13n node and execute i13n event
(move some shared functions to i13nUtils, to provide a small mixin for i13n functionalities)

### getI13nNode
when we use `createI13nNode` to decorate a node, for example `createI13nNode(Foo)`, it generate a template like
```
<I13nFoo> // everything about i13n and creating i13nNode happens here
     <Foo /> // original Foo, currently Foo cannot access anything about I13nFoo
</13nFoo>
```

in Foo, we might have some case want to access the i13n node, so provide `getI13nNode` to get the nearest i13nNode in context passed from parents. 

In the end, they are do something like
```
var I13nUtils = require('react-i13n').I13nUtils;
var DemoComponent = React.createClass({
    mixins: [I13nUtils],
    displayName: 'DemoComponent',
    render: function() {
        // this.getI13nNode() to access the i13nNode created by createI13nNode
    }
});
var I13nDemoComponent = createI13nNode(DemoComponent);
```

### executeI13nEvent
previously users will have to fire events like
```
var DemoComponent = React.createClass({
    displayName: 'DemoComponent',
    componentDidMount: function () {
         ReactI13n.getInstance.execute('pageview', {});
    }
});
```

now we provide executeI13nEvent for them, we can add some error handling and get the i13nNode into payload for them, (I will update all document that users should use this directly)
```
var I13nUtils = require('react-i13n').I13nUtils;
var DemoComponent = React.createClass({
    mixins: [I13nUtils],
    displayName: 'DemoComponent',
    componentDidMount: function () {
        // executeI13nEvent will find the i13nNode and append to the payload for you, which means the final payload will be
        // {i13nNode: [theI13nNode], foo: 'bar'}
        this.executeI13nEvent('someEventName', {foo: 'bar'}, function callback() {
            // callback
        });
    }
});
```

### add setParentNode

Users might have case that they want to dynamically change the I13nTree structor, they can to that by changing parent node of some `I13nNode`  

this is actually for mail's use case, they have some component which is not a parent in the react dom tree, but they want to inherit the data of it, so that they can do this by changing the i13n tree structor.

### Warning fix 

break immediately when we don't have any handlers for the event, instead of showing something like `ReactI13n handler timeout in 1000ms. +951ms`