### PR TITLE
enhance viewport detection performance

### DIFF
--- a/src/libs/I13nNode.js
+++ b/src/libs/I13nNode.js
@@ -77,6 +77,15 @@ I13nNode.prototype.getCustomAttribute = function getCustomAttribute (name) {
 };
 
 /**
+ * Get the react component
+ * @method getReactComponent
+ * @return {Object} the react component
+ */
+I13nNode.prototype.getReactComponent = function getReactComponent () {
+    return this._component;
+};
+
+/**
  * Get the dom node
  * @method getDOMNode
  * @return {Object} the DOMNode
@@ -224,6 +233,15 @@ I13nNode.prototype.removeChildNode = function removeChildNode (childNode) {
     var index = this._childrenNodes.indexOf(childNode);
     this._childrenNodes.splice(index, 1);
     this._isOrderDirty = true;
+};
+
+/**
+ * set react component
+ * @method setReactComponent
+ * @param {Object} react component
+ */
+I13nNode.prototype.setReactComponent = function setDOMNode (component) {
+    this._component = component;
 };
 
 /**

--- a/src/mixins/viewport/ViewportMixin.js
+++ b/src/mixins/viewport/ViewportMixin.js
@@ -30,13 +30,10 @@ var Viewport = {
 
     enterViewportCallback: null,
 
-    exitViewportCallback: null,
-
-    _detectElement: function (i13nNode, enterViewportCallback, exitViewportCallback) {
-        
+    _detectElement: function (i13nNode, enterViewportCallback, callback) {
         var element = i13nNode && i13nNode.getDOMNode();
         if (!element) {
-            return;
+            return callback && callback();
         }
         var rect = element.getBoundingClientRect();
         var viewportMargins = this.props.viewport.margins;
@@ -49,38 +46,20 @@ var Viewport = {
         } else {
             margins = viewportMargins;
         }
-        
         // Detect Screen Bottom                           // Detect Screen Top
         if ((rect.top < window.innerHeight + margins.top) && (rect.bottom > 0  - margins.bottom)) {
-            if (!i13nNode.isInViewport()) {
-                enterViewportCallback && enterViewportCallback();
-                i13nNode.setIsInViewport(true);
-            }
-        } else {
-            if (i13nNode.isInViewport()) {
-                exitViewportCallback && exitViewportCallback();
-                i13nNode.setIsInViewport(false);
-            }
+            enterViewportCallback && enterViewportCallback()
         }
+        callback && callback();
     },
 
-    _detectViewport: function () {
+    _detectViewport: function (callback) {
         var self = this;
         if (!self.isMounted()) {
             return;
         }
-        self._detectElement(self._i13nNode, self.enterViewportCallback, self.exitViewportCallback);
+        self._detectElement(self._i13nNode, self.enterViewportCallback, callback);
         self._subComponentsViewportDetection && self._subComponentsViewportDetection();
-    },
-
-    _detectHidden: function (hidden) {
-        var self = this;
-        if (!hidden) {
-            this._detectViewport();
-        } else {
-            self.exitViewportCallback && self.exitViewportCallback();
-            self.isOnViewport = false;
-        }
     },
 
     getDefaultProps: function () {
@@ -97,12 +76,10 @@ var Viewport = {
 
     subscribeViewportEvents: function () {
         this.subscribe('scroll', this._detectViewport);
-        this.subscribe('visibilitychange', this._detectHidden);
     },
 
     unsubscribeViewportEvents: function () {
         this.unsubscribe('scroll');
-        this.unsubscribe('visibilitychange');
     },
 
     onEnterViewport: function (callback) {

--- a/src/utils/clickHandler.js
+++ b/src/utils/clickHandler.js
@@ -55,6 +55,7 @@ module.exports = function clickHandler (e) {
     var isRedirectLink = isDefaultRedirectLink(target);
     var isPreventDefault = true;
     var props = self.props;
+    var followLink = (undefined !== props.followLink) ? props.followLink : props.follow;
     var href = '';
 
     // return and do nothing if the handler is append on a component without I13nMixin
@@ -65,8 +66,8 @@ module.exports = function clickHandler (e) {
     href = props.href;
 
     // if users disable the redirect by follow, force set it as false
-    if (undefined !== props.follow) {
-        isRedirectLink = props.follow;
+    if (undefined !== followLink) {
+        isRedirectLink = followLink;
     }
 
     // if it's not an anchor or this is a hash link url for page's internal links.

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -26,8 +26,9 @@ module.exports = function createI13nNode (Component, options) {
     var componentName = Component.displayName || Component.name || Component;
     options = options || {};
    
-    var I13nComponent = React.createClass(objectAssign({}, I13nMixin, {
+    var I13nComponent = React.createClass({
         displayName: 'I13n' + componentName,
+        mixins: [I13nMixin],
 
         /**
          * getDefaultProps
@@ -35,13 +36,15 @@ module.exports = function createI13nNode (Component, options) {
          * @return {Object} default props
          */
         getDefaultProps: function () {
-            return {
-                model: options.model || null,
-                i13nModel: options.i13nModel || null,
-                isLeafNode: options.isLeafNode || false,
-                bindClickEvent: options.bindClickEvent || false,
-                follow: options.follow || false
-            };
+            return objectAssign({}, {
+                model: null,
+                i13nModel: null,
+                isLeafNode: false,
+                bindClickEvent: false,
+                follow: false,
+                followLink: false,
+                scanLinks: null
+            }, options);
         },
         
         /**
@@ -73,7 +76,7 @@ module.exports = function createI13nNode (Component, options) {
                 props.children
             );
         }
-    }));
+    });
     
     if ('function' === typeof Component) {
         hoistNonReactStatics(I13nComponent, Component);

--- a/tests/unit/libs/I13nNode.js
+++ b/tests/unit/libs/I13nNode.js
@@ -160,4 +160,13 @@ describe('I13nNode', function () {
         i13nNode.setParentNode(parentNode);
         expect(i13nNode.getParentNode()).to.eql(parentNode);
     });
+    
+    it('should be able to get and set react component', function () {
+        var mockReactComponent = {
+            foo: 'bar'
+        };
+        var i13nNode = new I13nNode(null, {sec: 'foo'}, true, true);
+        i13nNode.setReactComponent(mockReactComponent);
+        expect(i13nNode.getReactComponent()).to.eql(mockReactComponent);
+    });
 });

--- a/tests/unit/utils/clickHandler.js
+++ b/tests/unit/utils/clickHandler.js
@@ -148,6 +148,23 @@ describe('clickHandler', function () {
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
+    
+    it('should not follow it if followLink is set to false', function (done) {
+        var i13nNode = new I13nNode(null, {});
+        var executedActions = [];
+        mockComponent.props.followLink = false;
+        mockClickEvent.preventDefault = function () {
+            executedActions.push('preventDefault');
+        };
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
+            expect(executedActions).to.eql(['preventDefault']);
+            done();
+        };
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
+        };
+        clickHandler.apply(mockComponent, [mockClickEvent]);
+    });
 
     it('should simply execute event without prevent default and redirection if the link is #', function (done) {
         var i13nNode = new I13nNode(null, {});


### PR DESCRIPTION
1. previously on page init, we detect viewport for `all` components, which might hurt the performance on page-init, change the implement here. For page init case, we recursively check viewport from the root, and break as long as the node is not in the viewport. 

2. support props.followLink so that we can integrate with `fluxible-router` better

@redonkulus @lingyan 