### PR TITLE
we shoud not set followLink as false by default

### DIFF
--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -42,7 +42,6 @@ module.exports = function createI13nNode (Component, options) {
                 isLeafNode: false,
                 bindClickEvent: false,
                 follow: false,
-                followLink: false,
                 scanLinks: null
             }, options);
         },

--- a/tests/unit/utils/clickHandler.js
+++ b/tests/unit/utils/clickHandler.js
@@ -165,6 +165,50 @@ describe('clickHandler', function () {
         };
         clickHandler.apply(mockComponent, [mockClickEvent]);
     });
+    
+    it('should follow it while follow is set to true', function (done) {
+        var i13nNode = new I13nNode(null, {});
+        var executedActions = [];
+        mockComponent.props.followLink = undefined;
+        mockComponent.props.follow = true;
+        mockClickEvent.preventDefault = function () {
+            executedActions.push('preventDefault');
+        };
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
+            callback();
+        };
+        document.location.assign = function () {
+            executedActions.push('assign');
+            expect(executedActions).to.eql(['preventDefault', 'assign']);
+            done();
+        }
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
+        };
+        clickHandler.apply(mockComponent, [mockClickEvent]);
+    });
+    
+    it('should follow it while followLink is set to true', function (done) {
+        var i13nNode = new I13nNode(null, {});
+        var executedActions = [];
+        mockComponent.props.followLink = true;
+        mockComponent.props.follow = false; // should not take follow
+        mockClickEvent.preventDefault = function () {
+            executedActions.push('preventDefault');
+        };
+        mockComponent.executeI13nEvent = function (eventName, payload, callback) {
+            callback();
+        };
+        document.location.assign = function () {
+            executedActions.push('assign');
+            expect(executedActions).to.eql(['preventDefault', 'assign']);
+            done();
+        }
+        mockComponent.getI13nNode = function () {
+            return i13nNode;
+        };
+        clickHandler.apply(mockComponent, [mockClickEvent]);
+    });
 
     it('should simply execute event without prevent default and redirection if the link is #', function (done) {
         var i13nNode = new I13nNode(null, {});


### PR DESCRIPTION
to integrate with fluxible-router, we suppose it's undefined unless we set it, https://github.com/yahoo/react-i13n/blob/master/src/utils/clickHandler.js#L58

which means we shouldn't give it a default value

@redonkulus @lingyan 