### PR TITLE
check component before detect viewport

### DIFF
--- a/src/mixins/I13nMixin.js
+++ b/src/mixins/I13nMixin.js
@@ -119,6 +119,7 @@ var I13nMixin = {
         if (!this._getReactI13n()) {
             return;
         }
+        clearTimeout(pageInitViewportDetectionTimeout);
         this._createI13nNode();
         this._i13nNode.setReactComponent(this);
     },
@@ -306,7 +307,10 @@ var I13nMixin = {
         self._detectViewport(function detectCallback () {
             if (self._i13nNode.isInViewport()) {
                 self._i13nNode.getChildrenNodes().forEach(function detectChildrenViewport (childNode) {
-                    childNode.getReactComponent()._recursiveDetectViewport();
+                    var reactComponent = childNode.getReactComponent();
+                    if (reactComponent) {
+                        reactComponent._recursiveDetectViewport();
+                    }
                 });
             }
         });


### PR DESCRIPTION
with #31 , we detect viewport recursively from the root , while we sometimes get 

```
Uncaught TypeError: Cannot read property '_recursiveDetectViewport' of undefined
```

we wait until latest `componentDidMount` happen then start detecting viewport from the root, and suppose we can always `getReactComponent` for each i13n node, it can be caused when we start detection but some component is still mounting, 

so do `clearTimeout(pageInitViewportDetectionTimeout);` in `componentWillMount` should solve the problem

also add error handling

@redonkulus @kfay