### PR TITLE
Ignore tmp folder on publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@
 /docs/
 /results/
 /src/
+/tmp/
 /tests/
 lcov-*
 xunit*


### PR DESCRIPTION
@kaesonho @redonkulus 

we are now publishing tmp folder to npm after running tests on CI