### PR TITLE
check hidden nodes when creating debug dashboards

### DIFF
--- a/src/utils/DebugDashboard.js
+++ b/src/utils/DebugDashboard.js
@@ -7,6 +7,21 @@ var EventListener = require('react/lib/EventListener');
 
 var uniqueId = 0;
 
+function checkHidden (DOMNode) {
+    if (DOMNode !== document) {
+        var styles = window.getComputedStyle(DOMNode) || {};
+        if ('none' === styles.display || 
+            'hidden' === styles.visibility || 
+            '0' === styles.opacity) { 
+            return true;
+        } else {
+            return checkHidden(DOMNode.parentNode);
+        }
+    } else {
+        return false;
+    }
+}
+
 function setupContainerPosition (DOMNode, container, dashboard) {
     var offset = cumulativeOffset(DOMNode);
     var left = offset.left + DOMNode.offsetWidth - 15;
@@ -47,6 +62,9 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
     var self = this;
     var DOMNode = i13nNode.getDOMNode();
     if (!DOMNode) {
+        return;
+    }
+    if (checkHidden(DOMNode)) {
         return;
     }
     var container = document.createElement('div');


### PR DESCRIPTION
@redonkulus @lingyan @hankhsiao 

An enhancement for the debug tool, previously we created a node for every i13nNode, even though it's not shown. 

this PR use `window.getComputedStyle` and check parent recursively. that takes some time but only happens when users enable the debug mode. 