### PR TITLE
Remove `Promise` and `Object.assign` polyfills

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,10 +137,10 @@ module.exports = function (grunt) {
                         env: env
                     }
                 },
-                command: 'node node_modules/istanbul/lib/cli.js cover --dir <%= project.coverage_dir %> -- ./node_modules/mocha/bin/_mocha <%= project.tmp %>/<%= project.unit %> --recursive --reporter xunit-file'
+                command: 'node node_modules/istanbul/lib/cli.js cover --dir <%= project.coverage_dir %> -- ./node_modules/mocha/bin/_mocha <%= project.tmp %>/<%= project.unit %> --require ./tests/setup --recursive --reporter xunit-file'
             },
             mocha: {
-                command: './node_modules/mocha/bin/mocha <%= project.tmp %>/<%= project.unit %> --recursive --reporter spec'
+                command: './node_modules/mocha/bin/mocha <%= project.tmp %>/<%= project.unit %> --require ./tests/setup --recursive --reporter spec'
             }
         },
         // webpack

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # react-i13n
 
-[![npm version](https://badge.fury.io/js/react-i13n.svg)](http://badge.fury.io/js/react-i13n) 
-[![Build Status](https://travis-ci.org/yahoo/react-i13n.svg?branch=master)](https://travis-ci.org/yahoo/react-i13n) 
-[![Coverage Status](https://coveralls.io/repos/yahoo/react-i13n/badge.svg?branch=master&service=github)](https://coveralls.io/github/yahoo/react-i13n?branch=master) 
+[![npm version](https://badge.fury.io/js/react-i13n.svg)](http://badge.fury.io/js/react-i13n)
+[![Build Status](https://travis-ci.org/yahoo/react-i13n.svg?branch=master)](https://travis-ci.org/yahoo/react-i13n)
+[![Coverage Status](https://coveralls.io/repos/yahoo/react-i13n/badge.svg?branch=master&service=github)](https://coveralls.io/github/yahoo/react-i13n?branch=master)
 [![Dependency Status](https://david-dm.org/yahoo/react-i13n.svg)](https://david-dm.org/yahoo/react-i13n)
 [![devDependency Status](https://david-dm.org/yahoo/react-i13n/dev-status.svg)](https://david-dm.org/yahoo/react-i13n#info=devDependencies)
 
@@ -27,6 +27,16 @@ Typically, you have to manually add instrumentation code throughout your applica
 ```
 npm install react-i13n --save
 ```
+
+## Runtime Compatibility
+
+react-i13n is written with ES2015 in mind and should be used along with polyfills
+for features like [`Promise`][Promise] and [`Object.assign`][objectAssign]
+in order to support all browsers and older versions of Node.js. We recommend using [Babel][babel].
+
+[Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[objectAssign]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+[babel]: https://babeljs.io/
 
 ## Usage
 
@@ -56,8 +66,8 @@ var DemoApp = React.createClass({
     },
     render: function () {
         ...
-        <I13nAnchor href="http://foo.bar" i13nModel={{action: 'click', label: 'foo'}}>...</I13nAnchor> 
-        // this link will be tracked, and the click event handlers provided by the plugin will get the model data as 
+        <I13nAnchor href="http://foo.bar" i13nModel={{action: 'click', label: 'foo'}}>...</I13nAnchor>
+        // this link will be tracked, and the click event handlers provided by the plugin will get the model data as
         // {site: 'foo', action: 'click', label: 'foo'}
     }
 });

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "debug": "^2.1.3",
     "fbjs": "^0.3.1",
     "hoist-non-react-statics": "^1.0.0",
-    "object-assign": "^4.0.0",
-    "promise": "^7.0.1",
     "setimmediate": "^1.0.2",
     "subscribe-ui-event": "^0.2.2"
   },
@@ -42,7 +40,9 @@
     "minimist": "^1.2.0",
     "mocha": "^2.0",
     "mockery": "^1.4.0",
+    "object-assign": "^4.0.0",
     "pre-commit": "^1.0.0",
+    "promise": "^7.0.1",
     "react": "^0.14.0-rc1",
     "react-dom": "^0.14.0-rc1",
     "react-tools": "<= 0.13.x",

--- a/src/libs/I13nNode.js
+++ b/src/libs/I13nNode.js
@@ -6,7 +6,6 @@
 'use strict';
 
 // var debug = require('debug')('I13nNode');
-var objectAssign = require('object-assign');
 var TAG_PATTERN = /<[^>]*>/g;
 
 /**
@@ -28,9 +27,9 @@ var I13nNode = function I13nNode (parentNode, model, isLeafNode, isViewportEnabl
     if ('function' === typeof model) {
         this._model = model;
     } else {
-        this._model = objectAssign({}, model);
+        this._model = Object.assign({}, model);
     }
-    
+
     this._childrenNodes = []; // children nodes
     this._DOMNode = null; // DOM node of the i13n node, will use setDOMNode to set it in componentDidMount
     this._customAttributes = {}; // any custom value want to set in the i13n node, can used to save some status in the handler functions
@@ -41,7 +40,7 @@ var I13nNode = function I13nNode (parentNode, model, isLeafNode, isViewportEnabl
     // _isOrderDirty used to check if we need to sort children nodes before we get position of one of it child
     // will set to true if we already sort them
     // set to false once we add/remove a child
-    this._isOrderDirty = false; 
+    this._isOrderDirty = false;
 
     // _isInViewport save the status if node is already shown in the viewport, if viewport check isn't enabled, then always set to true
     this._isInViewport = !isViewportEnabled ? true : false;
@@ -95,7 +94,7 @@ I13nNode.prototype.getDOMNode = function getDOMNode () {
 };
 
 /**
- * Get merged model which is traced to the root 
+ * Get merged model which is traced to the root
  * @method getMergedModel
  * @param {Boolean} debugMode indicate it's debug mode, will return additional information for debug tool
  * @return {Object} the merged model
@@ -103,7 +102,7 @@ I13nNode.prototype.getDOMNode = function getDOMNode () {
 I13nNode.prototype.getMergedModel = function getMergedModel (debugMode) {
     if (this._parentNode) {
         var parentModel = this._parentNode.getMergedModel(debugMode);
-        return objectAssign({}, parentModel, this.getModel(debugMode));
+        return Object.assign({}, parentModel, this.getModel(debugMode));
     } else {
         return this.getModel(debugMode);
     }
@@ -124,9 +123,9 @@ I13nNode.prototype.getModel = function getModel (debugMode) {
     } else {
         model = self._model;
     }
-    
+
     //always return new object to prevent reference issue
-    finalModel = objectAssign({}, model);
+    finalModel = Object.assign({}, model);
 
     if (debugMode) {
         // add the DOMNode to the returned model, so that it can be used in debug tool
@@ -176,7 +175,7 @@ I13nNode.prototype.getText = function getText (target) {
     if (!DOMNode && !target) {
         return '';
     }
-    var text = (target && (target.value || target.innerHTML)) || 
+    var text = (target && (target.value || target.innerHTML)) ||
         (DOMNode && (DOMNode.value || DOMNode.innerHTML));
     if (text) {
         text = text.replace(TAG_PATTERN, '');
@@ -245,7 +244,7 @@ I13nNode.prototype.setReactComponent = function setDOMNode (component) {
 };
 
 /**
- * Update DOM node 
+ * Update DOM node
  * @method setDOMNode
  * @param {Object} DOMNode
  */
@@ -287,11 +286,11 @@ I13nNode.prototype.setParentNode = function setParentNode (parentNode) {
  * @param {Object|Function} newModel the new i13n model
  */
 I13nNode.prototype.updateModel = function updateModel (newModel) {
-    // if i13n is a function, just assign it to _model, otherwise use object-assign to merge old and new model data
+    // if i13n is a function, just assign it to _model, otherwise use Object.assign to merge old and new model data
     if ('function' === typeof newModel) {
         this._model = newModel;
     } else {
-        this._model = objectAssign({}, this._model, newModel);
+        this._model = Object.assign({}, this._model, newModel);
     }
 };
 

--- a/src/libs/ReactI13n.js
+++ b/src/libs/ReactI13n.js
@@ -9,8 +9,6 @@ var debugLib = require('debug');
 var debug = debugLib('ReactI13n');
 var EventsQueue = require('./EventsQueue');
 var I13nNode = require('./I13nNode');
-var Promise = require('promise');
-var objectAssign = require('object-assign');
 var DEFAULT_HANDLER_TIMEOUT = 1000;
 var GLOBAL_OBJECT = ('client' === ENVIRONMENT) ? window : global;
 var ENVIRONMENT = (typeof window !== 'undefined') ? 'client' : 'server';
@@ -26,7 +24,7 @@ if ('client' === ENVIRONMENT) {
  * @param {Object} options options object
  * @param {Boolean} options.isViewportEnabled if enable viewport checking
  * @param {Object} options.rootModelData model data of root i13n node
- * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities 
+ * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities
  * @constructor
  */
 var ReactI13n = function ReactI13n (options) {
@@ -39,7 +37,7 @@ var ReactI13n = function ReactI13n (options) {
     this._isViewportEnabled = options.isViewportEnabled || false;
     this._rootModelData = options.rootModelData || {};
     this._handlerTimeout = options.handlerTimeout || DEFAULT_HANDLER_TIMEOUT;
-    
+
     // set itself to the global object so that we can get it anywhere by the static function getInstance
     GLOBAL_OBJECT.reactI13n = this;
 };
@@ -77,7 +75,7 @@ ReactI13n.prototype.createRootI13nNode = function createRootI13nNode () {
  */
 ReactI13n.prototype.execute = function execute (eventName, payload, callback) {
     var self = this;
-    payload = objectAssign({}, payload);
+    payload = Object.assign({}, payload);
     payload.env = ENVIRONMENT;
     payload.i13nNode = payload.i13nNode || this.getRootI13nNode();
     var promiseHandlers = this.getEventHandlers(eventName, payload);

--- a/src/mixins/I13nMixin.js
+++ b/src/mixins/I13nMixin.js
@@ -14,7 +14,6 @@ var EventListener = require('fbjs/lib/EventListener');
 var ViewportMixin = require('./viewport/ViewportMixin');
 var I13nUtils = require('./I13nUtils');
 var DebugDashboard = require('../utils/DebugDashboard');
-var objectAssign = require('object-assign');
 require('setimmediate');
 var IS_DEBUG_MODE = isDebugMode();
 var DEFAULT_SCAN_TAGS = ['a', 'button'];
@@ -205,7 +204,7 @@ var I13nMixin = {
             var i13nNode = new I13nNode(self._i13nNode, {}, true, reactI13n.isViewportEnabled());
             i13nNode.setDOMNode(element);
             self._subI13nComponents.push({
-                componentClickHandler: EventListener.listen(element, 'click', clickHandler.bind(objectAssign({}, self, {getI13nNode: function getI13nNodeForScannedNode() {
+                componentClickHandler: EventListener.listen(element, 'click', clickHandler.bind(Object.assign({}, self, {getI13nNode: function getI13nNodeForScannedNode() {
                     return i13nNode;
                 }}))),
                 i13nNode: i13nNode,

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -7,12 +7,11 @@
 
 var React = require('react');
 var I13nMixin = require('../mixins/I13nMixin');
-var objectAssign = require('object-assign');
 var hoistNonReactStatics = require('hoist-non-react-statics');
 
 /**
  * createI13nNode higher order function to create a Component with I13nNode functionality
- * @param {Object|String} Component the component you want to create a i13nNode 
+ * @param {Object|String} Component the component you want to create a i13nNode
  * @method createI13nNode
  */
 module.exports = function createI13nNode (Component, options) {
@@ -25,7 +24,7 @@ module.exports = function createI13nNode (Component, options) {
     }
     var componentName = Component.displayName || Component.name || Component;
     options = options || {};
-   
+
     var I13nComponent = React.createClass({
         displayName: 'I13n' + componentName,
         mixins: [I13nMixin],
@@ -36,7 +35,7 @@ module.exports = function createI13nNode (Component, options) {
          * @return {Object} default props
          */
         getDefaultProps: function () {
-            return objectAssign({}, {
+            return Object.assign({}, {
                 model: null,
                 i13nModel: null,
                 isLeafNode: false,
@@ -45,13 +44,13 @@ module.exports = function createI13nNode (Component, options) {
                 scanLinks: null
             }, options);
         },
-        
+
         /**
          * render
          * @method render
          */
         render: function () {
-            var props = objectAssign({}, {
+            var props = Object.assign({}, {
                 i13n: {
                     executeEvent: this.executeI13nEvent,
                     getI13nNode: this.getI13nNode
@@ -70,7 +69,7 @@ module.exports = function createI13nNode (Component, options) {
             );
         }
     });
-    
+
     if ('function' === typeof Component) {
         hoistNonReactStatics(I13nComponent, Component);
     }

--- a/src/utils/setupI13n.js
+++ b/src/utils/setupI13n.js
@@ -7,7 +7,6 @@
 var React = require('react');
 var ReactI13n = require('../libs/ReactI13n');
 var I13nUtils = require('../mixins/I13nUtils');
-var objectAssign = require('object-assign');
 
 /**
  * Create an app level component with i13n setup
@@ -15,7 +14,7 @@ var objectAssign = require('object-assign');
  * @param {Object} options passed into ReactI13n
  * @param {Boolean} options.isViewportEnabled if enable viewport checking
  * @param {Object} options.rootModelData model data of root i13n node
- * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities 
+ * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities
  * @param {Array} plugins plugins
  * @method setupI13n
  */
@@ -33,18 +32,18 @@ module.exports = function setupI13n (Component, options, plugins) {
         mixins: [I13nUtils],
 
         displayName: 'RootI13n' + componentName,
-    
+
         /**
          * componentWillMount
          * @method componentWillMount
          */
         componentWillMount: function () {
-            var reactI13n = ReactI13n.getInstance(); 
+            var reactI13n = ReactI13n.getInstance();
             reactI13n.createRootI13nNode();
         },
 
         render: function () {
-            var props = objectAssign({}, {
+            var props = Object.assign({}, {
                 i13n: {
                     executeEvent: this.executeI13nEvent,
                     getI13nNode: this.getI13nNode

--- a/tests/functional/bootstrap.js
+++ b/tests/functional/bootstrap.js
@@ -1,4 +1,8 @@
 /*global window */
+
+window.Promise = require('promise');
+window.Object.assign = require('object-assign');
+
 window.React = require('react');
 window.ReactDOM = require('react-dom');
 

--- a/tests/setup/index.js
+++ b/tests/setup/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+if (!global.Promise) {
+    global.Promise = require('promise');
+}
+
+if (!Object.assign) {
+    Object.assign = require('object-assign');
+}


### PR DESCRIPTION
This removes the `Promise` and `Object.assign` polyfills, provided by the `promise` and `object-assign` packages respectively, from the `dependencies`.

These polyfills are now required to be added to the runtime before loading this package.

Fixes #60