### PR TITLE
Bump fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^2.1.3",
-    "fbjs": "^0.3.1",
+    "fbjs": "^0.6.0",
     "hoist-non-react-statics": "^1.0.0",
     "setimmediate": "^1.0.2",
     "subscribe-ui-event": "^0.2.2"


### PR DESCRIPTION
Not sure if we really need `fbjs` as it is quite large. (we are using `fbjs/lib/EventListener`)

Bumping the version as `React` already using latest version of `fbjs`

