### PR TITLE
make ref optional

### DIFF
--- a/docs/api/createI13nNode.md
+++ b/docs/api/createI13nNode.md
@@ -18,6 +18,7 @@ The `high order component` integrates the functionalities of i13n, it returns a 
  * `defaultProps` - defaultProps object, it would be the default `props` of that I13nNode, you can also pass options with `props` to overwrite it.
  * `options` - options object
  * `options.displayName` - display name of the wrapper component, will fallback to `I13n` + original display name
+ * `options.refToWrappedComponent` - ref to the wrapped component, then you can use `{i13nComponent}.refs[options.refToWrappedComponent]` to access the wrapped component.
 
 For example, if you want to enable link tracking, you will need to create an anchor with the `createI13nNode` and enable the click tracking.
 

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -14,7 +14,8 @@ var hoistNonReactStatics = require('hoist-non-react-statics');
  * @param {Object|String} Component the component you want to create a i13nNode
  * @param {Object} defaultProps default props
  * @param {Object} options
- * @param {Object} options.displayName
+ * @param {Object} options.displayName display name
+ * @param {Object} options.refToWrappedComponent ref name to wrapped component
  * @method createI13nNode
  */
 module.exports = function createI13nNode (Component, defaultProps, options) {
@@ -56,12 +57,15 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
          */
         render: function () {
             var props = Object.assign({}, {
-                ref: 'wrappedElement',
                 i13n: {
                     executeEvent: this.executeI13nEvent,
                     getI13nNode: this.getI13nNode
                 }
             }, this.props);
+
+            if (options.refToWrappedComponent) {
+                props.ref = options.refToWrappedComponent;
+            }
 
             // delete the props that only used in this level
             props.model = undefined;

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -414,7 +414,7 @@ describe('createI13nNode', function () {
                 return React.createElement('div');
             }
         });
-        var I13nTestComponent = createI13nNode(TestComponent);
+        var I13nTestComponent = createI13nNode(TestComponent, {}, {refToWrappedComponent: 'wrappedElement'});
         mockData.reactI13n.execute = function () {};
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent), container);


### PR DESCRIPTION
related to #74 
adding ref breaks tests which are using `jsx`, make it optional

```
Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding
 a ref to a component that was not created inside a component's `render` method, or you have multiple 
copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
```
@redonkulus @lingyan @maximilianschmitt 