### PR TITLE
Fixed wrong reference to props

### DIFF
--- a/src/mixins/I13nMixin.js
+++ b/src/mixins/I13nMixin.js
@@ -227,7 +227,7 @@ var I13nMixin = {
             return this.shouldFollowLink();
         }
 
-        return (undefined !== props.followLink) ? props.followLink : props.follow;
+        return (undefined !== this.props.followLink) ? this.props.followLink : this.props.follow;
     },
 
     /**


### PR DESCRIPTION
@kaesonho 

Sorry, props was an argument pass in to `_shouldFollowLink()`, but I remove it before commit.