### PR TITLE
only delete i13nModal

### DIFF
--- a/src/mixins/viewport/ViewportMixin.js
+++ b/src/mixins/viewport/ViewportMixin.js
@@ -7,6 +7,11 @@
 
 var React = require('react');
 var subscribe = require('subscribe-ui-event').subscribe;
+var DEFAULT_VIEWPORT_MARGINS = {
+    usePercent: false,
+    top: 20,
+    bottom: 20
+};
 
 /* Viewport mixin assumes you are on browser and already have the scroll lib */
 var Viewport = {
@@ -30,7 +35,8 @@ var Viewport = {
             return callback && callback();
         }
         var rect = element.getBoundingClientRect();
-        var viewportMargins = this.props.viewport.margins;
+        var viewportMargins = Object.assign({}, DEFAULT_VIEWPORT_MARGINS, 
+            (this.props.viewport && this.props.viewport.margins) || {});
         var margins;
         if (viewportMargins.usePercent) {
             margins = {
@@ -54,18 +60,6 @@ var Viewport = {
         }
         self._detectElement(self._i13nNode, self.enterViewportCallback, callback);
         self._subComponentsViewportDetection && self._subComponentsViewportDetection();
-    },
-
-    getDefaultProps: function () {
-        return {
-            viewport: {
-                margins: {
-                    usePercent: false,
-                    top: 20,
-                    bottom: 20
-                }
-            }
-        };
     },
 
     subscribeViewportEvents: function () {

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -42,7 +42,6 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
          */
         getDefaultProps: function () {
             return Object.assign({}, {
-                model: null,
                 i13nModel: null,
                 isLeafNode: false,
                 bindClickEvent: false,
@@ -68,9 +67,7 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
             }
 
             // delete the props that only used in this level
-            props.model = undefined;
             props.i13nModel = undefined;
-            props.viewport = undefined;
 
             return React.createElement(
                 Component,


### PR DESCRIPTION
we delete `props.model`/`props.i13nModel`/`props.viewport`, which might generate some issue if users intend to pass `props.model` or `props.viewport` for other purpose. (deleting `props.i13nModel` makes sense since it's just used by react-i13n) 

here don't define default props of `props.viewport` and `props.model`, and don't delete it. 


@redonkulus  @lingyan 