### PR TITLE
Added scrollableContainerId option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function (grunt) {
                 command: 'node node_modules/istanbul/lib/cli.js cover --dir <%= project.coverage_dir %> -- ./node_modules/mocha/bin/_mocha <%= project.tmp %>/<%= project.unit %> --require ./tests/setup --recursive --reporter xunit-file'
             },
             mocha: {
-                command: './node_modules/mocha/bin/mocha <%= project.tmp %>/<%= project.unit %> --require ./tests/setup --recursive --reporter spec'
+                command: 'node ./node_modules/mocha/bin/mocha <%= project.tmp %>/<%= project.unit %> --require ./tests/setup --recursive --reporter spec'
             }
         },
         // webpack

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "^2.1.3",
     "hoist-non-react-statics": "^1.0.0",
     "setimmediate": "^1.0.2",
-    "subscribe-ui-event": "^1.0.5"
+    "subscribe-ui-event": "^1.0.7"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",

--- a/src/libs/ReactI13n.js
+++ b/src/libs/ReactI13n.js
@@ -25,6 +25,10 @@ if ('client' === ENVIRONMENT) {
  * @param {Boolean} options.isViewportEnabled if enable viewport checking
  * @param {Object} options.rootModelData model data of root i13n node
  * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities
+ * @param {String} options.scrollableContainerId id of the scrollable element that your components
+ *     reside within.  Normally, you won't need to provide a value for this.  This is only to
+ *     support viewport checking when your components are contained within a scrollable element.
+ *     Currently, only elements that fill the viewport are supported.
  * @constructor
  */
 var ReactI13n = function ReactI13n (options) {
@@ -37,6 +41,7 @@ var ReactI13n = function ReactI13n (options) {
     this._isViewportEnabled = options.isViewportEnabled || false;
     this._rootModelData = options.rootModelData || {};
     this._handlerTimeout = options.handlerTimeout || DEFAULT_HANDLER_TIMEOUT;
+    this._scrollableContainerId = options.scrollableContainerId || undefined;
 
     // set itself to the global object so that we can get it anywhere by the static function getInstance
     GLOBAL_OBJECT.reactI13n = this;
@@ -160,6 +165,27 @@ ReactI13n.prototype.isViewportEnabled = function isViewportEnabled () {
 };
 
 /**
+ * Get scrollableContainerId value
+ * @method getScrollableContainerId
+ * @return {String} scrollableContainerId value
+ */
+ReactI13n.prototype.getScrollableContainerId = function getScrollableContainerId () {
+    return this._scrollableContainerId;
+};
+
+/**
+ * Get scrollable container DOM node
+ * @method getScrollableContainerDOMNode
+ * @return {Object} scrollable container DOM node.  This will be undefined if no
+ *     scrollableContainerId was set, or null if the element was not found in the DOM.
+ */
+ReactI13n.prototype.getScrollableContainerDOMNode = function getScrollableContainerDOMNode () {
+    if (this._scrollableContainerId) {
+        return document && document.getElementById(this._scrollableContainerId);
+    }
+};
+
+/**
  * Get root i13n node
  * @method getRootI13nNode
  * @return {Object} root react i13n node
@@ -181,6 +207,8 @@ ReactI13n.prototype.updateOptions = function updateOptions (options) {
         options.isViewportEnabled : this._isViewportEnabled;
     this._rootModelData = options.rootModelData ? options.rootModelData : this._rootModelData;
     this._handlerTimeout = options.handlerTimeout ? options.handlerTimeout : this._handlerTimeout;
+    this._scrollableContainerId = 'undefined' === typeof options.scrollableContainerId ?
+                                  this._scrollableContainerId : options.scrollableContainerId;
 };
 
 module.exports = ReactI13n;

--- a/src/mixins/I13nMixin.js
+++ b/src/mixins/I13nMixin.js
@@ -99,6 +99,7 @@ var I13nMixin = {
         if (!self._getReactI13n()) {
             return;
         }
+        var reactI13n = self._getReactI13n();
 
         // bind the click event for i13n component if it's enabled
         if (self.props.bindClickEvent) {
@@ -108,8 +109,15 @@ var I13nMixin = {
         self._i13nNode.setDOMNode(ReactDOM.findDOMNode(self));
 
         // enable viewport checking if enabled
-        if (self._getReactI13n().isViewportEnabled()) {
-            self.subscribeViewportEvents();
+        if (reactI13n.isViewportEnabled()) {
+            var options = {};
+            if (reactI13n.getScrollableContainerDOMNode) {
+                var domNode = reactI13n.getScrollableContainerDOMNode();
+                if (domNode) {
+                    options.target = domNode;
+                }
+            }
+            self.subscribeViewportEvents(options);
             self._enableViewportDetection();
         }
         self.executeI13nEvent('created', {});

--- a/src/mixins/viewport/ViewportMixin.js
+++ b/src/mixins/viewport/ViewportMixin.js
@@ -62,8 +62,8 @@ var Viewport = {
         self._subComponentsViewportDetection && self._subComponentsViewportDetection();
     },
 
-    subscribeViewportEvents: function () {
-        this.subscription = subscribe('scrollEnd', this._detectViewport);
+    subscribeViewportEvents: function (options) {
+        this.subscription = subscribe('scrollEnd', this._detectViewport, options || {});
     },
 
     unsubscribeViewportEvents: function () {

--- a/tests/unit/libs/ReactI13n.js
+++ b/tests/unit/libs/ReactI13n.js
@@ -121,4 +121,20 @@ describe('ReactI13n', function () {
             done();
         });
     });
+
+    it('should be able to set a scrollableContainerId', function () {
+        var reactI13n = new ReactI13n({
+            scrollableContainerId: 'scrollable-test'
+        });
+
+        expect(reactI13n.getScrollableContainerId()).to.eql('scrollable-test');
+    });
+
+    it('should have an undefined scrollableContainerDOMNode if the scrollableContainerId is undefined', function () {
+        var reactI13n = new ReactI13n({
+            isViewportEnabled: true
+        });
+
+        expect(reactI13n.getScrollableContainerDOMNode()).to.eql(undefined);
+    });
 });


### PR DESCRIPTION
This is one way to support viewport checking when components are contained within a scrollable element, as mentioned in [#84](https://github.com/yahoo/react-i13n/issues/84).

This is the solution that is currently working for me.  Note that it only supports the use case where the scrollable element fills the viewport.