### PR TITLE
do not pass i13n props to string components

### DIFF
--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -27,6 +27,7 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
         return;
     }
     var componentName = Component.displayName || Component.name || Component;
+    var componentIsFunction = 'function' === typeof Component;
     defaultProps = defaultProps || {};
     options = options || {};
 
@@ -69,6 +70,24 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
             // delete the props that only used in this level
             props.i13nModel = undefined;
 
+            if (!componentIsFunction) {
+              // filter props to avoid to pass unknown props to components such <a> or <button>
+              var propsToFilter = {
+                  i13n: true,
+                  i13nModel: true,
+                  follow: true,
+                  isLeafNode: true,
+                  bindClickEvent: true,
+                  scanLinks: true
+              };
+              props = Object.keys(props).reduce(function reduceProps(propsMap, propName) {
+                  if (!propsToFilter.hasOwnProperty(propName)) {
+                    propsMap[propName] = props[propName];
+                  }
+                  return propsMap;
+              }, {});
+            }
+
             return React.createElement(
                 Component,
                 props,
@@ -77,7 +96,7 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
         }
     });
 
-    if ('function' === typeof Component) {
+    if (componentIsFunction) {
         hoistNonReactStatics(I13nComponent, Component);
     }
 

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -44,6 +44,14 @@ MockReactI13n.getInstance = function () {
     return mockData.reactI13n;
 };
 
+function findProps(elem) {
+  try {
+    return elem[Object.keys(elem).find(function (key) {
+      return key.indexOf('__reactInternalInstance') === 0;
+    })]._currentElement.props;
+  } catch (e) {}
+}
+
 describe('createI13nNode', function () {
     beforeEach(function (done) {
         jsdom.env('<html><body></body></html>', [], function (err, window) {
@@ -431,5 +439,24 @@ describe('createI13nNode', function () {
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent), container);
         expect(component.refs.wrappedElement).to.be.a(TestComponent);
+    });
+
+    it('should not pass i13n props to string components', function () {
+      var props = {
+          i13nModel: {sec: 'foo'},
+          href: '#/foobar'
+      };
+      var I13nTestComponent = createI13nNode('a', {
+          follow: true,
+          isLeafNode: true,
+          bindClickEvent: true,
+          scanLinks: {enable: true}
+      }, {
+          refToWrappedComponent: 'wrappedElement'
+      });
+      mockData.reactI13n.execute = function () {};
+      var container = document.createElement('div');
+      var component = ReactDOM.render(React.createElement(I13nTestComponent, props), container);
+      expect(findProps(component.refs.wrappedElement)).to.eql({href: '#/foobar', children: undefined});
     });
 });


### PR DESCRIPTION
To avoid to pass i13n props to string components such `a` or `button`, we can filter the props before passing them to the wrapped component. So React ^15.2.0 will not warn about unknown props. What do you think?