### PR TITLE
fix leak on server side, not store singleton instance to global object

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ var I13nDempApp = setupI13n(DemoApp, {
 
 Or follow our guide and [create your own](./docs/guides/createPlugins.md).
 
-
 ## I13n Tree
 ![I13n Tree](https://cloud.githubusercontent.com/assets/3829183/7980892/0b38eb70-0a60-11e5-8cc2-712ec42089fc.png)
 

--- a/docs/api/setupI13n.md
+++ b/docs/api/setupI13n.md
@@ -29,6 +29,15 @@ var I13nDempApp = setupI13n(DemoApp, {
 // then you could use I13nDemoApp to render you app
 ```
 
+### Create and access the ReactI13n instance
+
+What we do with `setupI13n` is that we will create the `ReactI13n` instance, along with a root node of the I13nTree, passing them via component context to the children. 
+
+It's designed to work within React components, you should be able to just use [utilFuctions](https://github.com/yahoo/react-i13n/blob/master/docs/guides/utilFunctions.md) and trigger i13n events. In case you want to do this out of React components, you can access `window._reactI13nInstance` directly.
+
+If you have multiple React trees in one page, we will create multiple i13n trees based on how many React tree you have. On client side the [utilFuctions](https://github.com/yahoo/react-i13n/blob/master/docs/guides/utilFunctions.md) still work based on the global instance object, while on server side, only the children under `setupI13n` can get the React i13n instance as we don't have a proper way to share the ReactI13n instance without causing [memory leak](https://github.com/yahoo/react-i13n/pull/100).
+
+
 ### Util Functions
 
 You will get i13n util functions automatically via `this.props.i13n` by using `setupI13n`, more detail please refer to [util functions](../guides/utilFunctions.md).

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "promise": "^7.0.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
+    "webpack": "^1.13.1",
     "xunit-file": "~0.0.7"
   },
   "keywords": [

--- a/src/mixins/I13nMixin.js
+++ b/src/mixins/I13nMixin.js
@@ -14,6 +14,7 @@ var DebugDashboard = require('../utils/DebugDashboard');
 var I13nUtils = require('./I13nUtils');
 var listen = require('subscribe-ui-event').listen;
 var ReactI13n = require('../libs/ReactI13n');
+var I13nNode = require('../libs/I13nNode');
 var ViewportMixin = require('./viewport/ViewportMixin');
 require('setimmediate');
 var IS_DEBUG_MODE = isDebugMode();
@@ -137,9 +138,6 @@ var I13nMixin = {
      * @method componentWillMount
      */
     componentWillMount: function () {
-        if (!this._getReactI13n()) {
-            return;
-        }
         clearTimeout(pageInitViewportDetectionTimeout);
         this._createI13nNode();
         this._i13nNode.setReactComponent(this);
@@ -366,14 +364,15 @@ var I13nMixin = {
     _createI13nNode: function () {
         // check if reactI13n is initialized successfully, otherwise return
         var self = this;
-        var I13nNode = self._getReactI13n().getI13nNodeClass();
         var parentI13nNode = self._getParentI13nNode();
+        var reactI13n = self._getReactI13n();
+        var I13nNodeClass = (reactI13n && reactI13n.getI13nNodeClass()) || I13nNode;
         // TODO @kaesonho remove BC for model
-        self._i13nNode = new I13nNode(
+        self._i13nNode = new I13nNodeClass(
             parentI13nNode,
             self.props.i13nModel || self.props.model,
             self.isLeafNode(),
-            self._getReactI13n().isViewportEnabled());
+            reactI13n && reactI13n.isViewportEnabled());
     },
 
     /**

--- a/src/utils/setupI13n.js
+++ b/src/utils/setupI13n.js
@@ -7,6 +7,7 @@
 var React = require('react');
 var ReactI13n = require('../libs/ReactI13n');
 var I13nUtils = require('../mixins/I13nUtils');
+var IS_CLIENT = typeof window !== 'undefined';
 
 /**
  * Create an app level component with i13n setup
@@ -25,11 +26,6 @@ module.exports = function setupI13n (Component, options, plugins) {
     var RootI13nComponent;
     var componentName = Component.displayName || Component.name;
 
-    var reactI13n = new ReactI13n(options);
-    plugins.forEach(function setPlugin(plugin) {
-        reactI13n.plug(plugin);
-    });
-
     RootI13nComponent = React.createClass({
 
         mixins: [I13nUtils],
@@ -43,7 +39,16 @@ module.exports = function setupI13n (Component, options, plugins) {
          * @method componentWillMount
          */
         componentWillMount: function () {
-            var reactI13n = ReactI13n.getInstance();
+            var reactI13n = new ReactI13n(options);
+            this._reactI13nInstance = reactI13n;
+            // we might have case to access reactI13n instance to execute event outside react components
+            // assign reactI13n to window
+            if (IS_CLIENT) {
+                window._reactI13nInstance = reactI13n;
+            }
+            plugins.forEach(function setPlugin(plugin) {
+                reactI13n.plug(plugin);
+            });
             reactI13n.createRootI13nNode();
         },
 
@@ -51,7 +56,8 @@ module.exports = function setupI13n (Component, options, plugins) {
             var props = Object.assign({}, {
                 i13n: {
                     executeEvent: this.executeI13nEvent,
-                    getI13nNode: this.getI13nNode
+                    getI13nNode: this.getI13nNode,
+                    reactI13nInstance: this._reactI13nInstance
                 }
             }, this.props);
             return React.createElement(

--- a/tests/unit/libs/ReactI13n.js
+++ b/tests/unit/libs/ReactI13n.js
@@ -15,7 +15,6 @@ describe('ReactI13n', function () {
         var reactI13n = new ReactI13n({
             isViewportEnabled: true
         });
-        expect(ReactI13n.getInstance()).to.eql(reactI13n); // static function should be able to get the instance we created
         expect(reactI13n.isViewportEnabled()).to.eql(true);
     });
     

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -40,16 +40,14 @@ var mockSubscribe = {
     }
 };
 var mockClickHandler = function () {};
-MockReactI13n.getInstance = function () {
-    return mockData.reactI13n;
-};
 
 function findProps(elem) {
-  try {
-    return elem[Object.keys(elem).find(function (key) {
-      return key.indexOf('__reactInternalInstance') === 0;
-    })]._currentElement.props;
-  } catch (e) {}
+    try {
+        return elem[Object.keys(elem).find(function (key) {
+            return key.indexOf('__reactInternalInstance') === 0 || 
+                key.indexOf('_reactInternalComponent') === 0;
+        })]._currentElement.props;
+    } catch (e) {}
 }
 
 describe('createI13nNode', function () {
@@ -89,6 +87,7 @@ describe('createI13nNode', function () {
                     return mockData.isViewportEnabled;
                 }
             };
+            global.window._reactI13nInstance = mockData.reactI13n;
 
             done();
         });
@@ -182,7 +181,7 @@ describe('createI13nNode', function () {
             }
         });
         var I13nTestComponent = createI13nNode(TestComponent);
-        mockData.reactI13n = null;
+        window._reactI13nInstance = null;
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {}), container);
         expect(component).to.be.an('object');
@@ -442,21 +441,21 @@ describe('createI13nNode', function () {
     });
 
     it('should not pass i13n props to string components', function () {
-      var props = {
-          i13nModel: {sec: 'foo'},
-          href: '#/foobar'
-      };
-      var I13nTestComponent = createI13nNode('a', {
-          follow: true,
-          isLeafNode: true,
-          bindClickEvent: true,
-          scanLinks: {enable: true}
-      }, {
-          refToWrappedComponent: 'wrappedElement'
-      });
-      mockData.reactI13n.execute = function () {};
-      var container = document.createElement('div');
-      var component = ReactDOM.render(React.createElement(I13nTestComponent, props), container);
-      expect(findProps(component.refs.wrappedElement)).to.eql({href: '#/foobar', children: undefined});
+        var props = {
+            i13nModel: {sec: 'foo'},
+            href: '#/foobar'
+        };
+        var I13nTestComponent = createI13nNode('a', {
+            follow: true,
+            isLeafNode: true,
+            bindClickEvent: true,
+            scanLinks: {enable: true}
+        }, {
+            refToWrappedComponent: 'wrappedElement'
+        });
+        mockData.reactI13n.execute = function () {};
+        var container = document.createElement('div');
+        var component = ReactDOM.render(React.createElement(I13nTestComponent, props), container);
+        expect(findProps(component.refs.wrappedElement)).to.eql({href: '#/foobar', children: undefined});
     });
 });


### PR DESCRIPTION
@lingyan @redonkulus 

we are storing rootI13nNode and reactI13nInstance on the global object, which causes memory leak, we are leaking all the `i13n react component` in memory on server side, because they eventually have a reference to the  rootI13nNode

the solution here is just let `setupI13n` create that instance and pass it through `context`,
so that each I13n component can still get the instance.
also rootI13nNode can just store in the reactI13n instance.

After the change, we can see there's no leaking on i13nNodes now
<img width="1353" alt="screen shot 2016-08-08 at 10 42 52 am" src="https://cloud.githubusercontent.com/assets/3829183/17490011/bb5a41ea-5d55-11e6-8ad2-38d0c4317bfb.png">
