### PR TITLE
Revert "Move react & react-dom to dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   "dependencies": {
     "debug": "^2.1.3",
     "hoist-non-react-statics": "^1.0.0",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0",
     "setimmediate": "^1.0.2",
     "subscribe-ui-event": "^1.0.14"
   },
@@ -57,6 +55,10 @@
     "i13n",
     "instrumentation"
   ],
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
+  },
   "precommit": [
     "lint",
     "test"


### PR DESCRIPTION
Reverts yahoo/react-i13n#109

for some case we are seeing app is installing react and react-dom twice if app level defines `0.14.x`, let's revert this change first then we can keep investigate this

@redonkulus 