### PR TITLE
do not pass i13n related props, only pass props.i13n when it is enabled

### DIFF
--- a/docs/api/createI13nNode.md
+++ b/docs/api/createI13nNode.md
@@ -19,6 +19,7 @@ The `high order component` integrates the functionalities of i13n, it returns a 
  * `options` - options object
  * `options.displayName` - display name of the wrapper component, will fallback to `I13n` + original display name
  * `options.refToWrappedComponent` - ref to the wrapped component, then you can use `{i13nComponent}.refs[options.refToWrappedComponent]` to access the wrapped component.
+ * `options.passUtilFunctionsByProps` - true to allow i13n util function to be passed via `props.i13n`
 
 For example, if you want to enable link tracking, you will need to create an anchor with the `createI13nNode` and enable the click tracking.
 
@@ -59,4 +60,4 @@ var I13nDiv = createI13nNode('div', {
 
 ### Utils Functions
 
-You will get i13n util functions automatically via `this.props.i13n` by using `createI13nNode`, more detail please refer to [util functions](../guide/utilFunctions.md).
+If you set `options.passUtilFunctionsByProps=true`, you will get i13n util functions via `this.props.i13n` by using `createI13nNode`, more detail please refer to [util functions](../guide/utilFunctions.md).

--- a/docs/api/createI13nNode.md
+++ b/docs/api/createI13nNode.md
@@ -19,7 +19,7 @@ The `high order component` integrates the functionalities of i13n, it returns a 
  * `options` - options object
  * `options.displayName` - display name of the wrapper component, will fallback to `I13n` + original display name
  * `options.refToWrappedComponent` - ref to the wrapped component, then you can use `{i13nComponent}.refs[options.refToWrappedComponent]` to access the wrapped component.
- * `options.passUtilFunctionsByProps` - true to allow i13n util function to be passed via `props.i13n`
+ * `options.skipUtilFunctionsByProps` - true to prevent i13n util function to be passed via `props.i13n`
 
 For example, if you want to enable link tracking, you will need to create an anchor with the `createI13nNode` and enable the click tracking.
 
@@ -60,4 +60,4 @@ var I13nDiv = createI13nNode('div', {
 
 ### Utils Functions
 
-If you set `options.passUtilFunctionsByProps=true`, you will get i13n util functions via `this.props.i13n` by using `createI13nNode`, more detail please refer to [util functions](../guide/utilFunctions.md).
+You will get i13n util functions via `this.props.i13n` by using `createI13nNode`, more detail please refer to [util functions](../guide/utilFunctions.md).

--- a/docs/guides/utilFunctions.md
+++ b/docs/guides/utilFunctions.md
@@ -2,7 +2,7 @@
 
 We provides util functions for you to easily access the resource provided by `react-i13n`, you have two options to get the util functions, 
 
-* `props` - When you are using [setupI13n](../api/setupI13n.md) or [createI13nNode](../api/createI13nNode.md) with `options.passUtilFunctionsByProps=true` , we will pass util functions via `this.props.i13n`. Please note that starts from `2.3.0`, it's not passed by default due to the unknown props warning from `react@15.x`.
+* `props` - When you are using [setupI13n](../api/setupI13n.md) or [createI13nNode](../api/createI13nNode.md), we will pass util functions via `this.props.i13n`. Please note that starts from `2.3.0`, you can pass `skipUtilFunctionsByProps=true` to prevent `props.i13n` being passed to fix the unknown props warning from `react@15.x`.
 * `context` - You can always define `contextTypes` and access util functions via `context`, i.e., `this.context.i13n`.
 
 ```js
@@ -15,7 +15,7 @@ var DemoComponent = React.createClass({
     }
 });
 
-var I13nDemoComponent = createI13nNode(DemoComponent, {}, {passUtilFunctionsByProps: true});
+var I13nDemoComponent = createI13nNode(DemoComponent);
 ```
 
 ```js
@@ -52,5 +52,5 @@ var DemoComponent = React.createClass({
     }
 });
 
-var I13nDemoComponent = createI13nNode(DemoComponent, {}, {passUtilFunctionsByProps: true});
+var I13nDemoComponent = createI13nNode(DemoComponent);
 ```

--- a/docs/guides/utilFunctions.md
+++ b/docs/guides/utilFunctions.md
@@ -2,7 +2,7 @@
 
 We provides util functions for you to easily access the resource provided by `react-i13n`, you have two options to get the util functions, 
 
-* `props` - When you are using [setupI13n](../api/setupI13n.md) or [createI13nNode](../api/createI13nNode.md), we will automatically pass util functions via `this.props.i13n`.
+* `props` - When you are using [setupI13n](../api/setupI13n.md) or [createI13nNode](../api/createI13nNode.md) with `options.passUtilFunctionsByProps=true` , we will pass util functions via `this.props.i13n`. Please note that starts from `2.3.0`, it's not passed by default due to the unknown props warning from `react@15.x`.
 * `context` - You can always define `contextTypes` and access util functions via `context`, i.e., `this.context.i13n`.
 
 ```js
@@ -15,7 +15,7 @@ var DemoComponent = React.createClass({
     }
 });
 
-var I13nDemoComponent = createI13nNode(DemoComponent);
+var I13nDemoComponent = createI13nNode(DemoComponent, {}, {passUtilFunctionsByProps: true});
 ```
 
 ```js
@@ -52,5 +52,5 @@ var DemoComponent = React.createClass({
     }
 });
 
-var I13nDemoComponent = createI13nNode(DemoComponent);
+var I13nDemoComponent = createI13nNode(DemoComponent, {}, {passUtilFunctionsByProps: true});
 ```

--- a/src/mixins/I13nMixin.js
+++ b/src/mixins/I13nMixin.js
@@ -96,7 +96,6 @@ var I13nMixin = {
      */
     componentDidMount: function () {
         var self = this;
-
         var reactI13n = self._getReactI13n();
         if (!reactI13n) {
             return;

--- a/src/mixins/I13nUtils.js
+++ b/src/mixins/I13nUtils.js
@@ -1,6 +1,5 @@
 var React = require('react');
 var ReactI13n = require('../libs/ReactI13n');
-var IS_CLIENT = typeof window !== 'undefined';
 
 /**
  * React.js I13n Utils Mixin
@@ -62,7 +61,7 @@ var I13nUtils = {
             if ('production' !== process.env.NODE_ENV) {
                 errorMessage = 'ReactI13n instance is not found, ' + 
                     'please make sure you have setupI13n on the root component. ';
-                if (!IS_CLIENT) {
+                if (typeof window === 'undefined') {
                     errorMessage += 'On server side, ' + 
                         'you can only execute the i13n event on the components under setupI13n, ' + 
                         'please make sure you are calling executeI13nEvent correctly';
@@ -91,7 +90,7 @@ var I13nUtils = {
      */
     _getReactI13n: function () {
         var globalReactI13n;
-        if (IS_CLIENT) {
+        if (typeof window !== 'undefined') {
             globalReactI13n = window._reactI13nInstance;
         }
         return this._reactI13nInstance || 

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -14,8 +14,9 @@ var hoistNonReactStatics = require('hoist-non-react-statics');
  * @param {Object|String} Component the component you want to create a i13nNode
  * @param {Object} defaultProps default props
  * @param {Object} options
- * @param {Object} options.displayName display name
- * @param {Object} options.refToWrappedComponent ref name to wrapped component
+ * @param {String} options.displayName display name
+ * @param {String} options.refToWrappedComponent ref name to wrapped component
+ * @param {Boolean} options.passUtilFunctionsByProps true to allow i13n util function to be passed via props.i13n
  * @method createI13nNode
  */
 module.exports = function createI13nNode (Component, defaultProps, options) {
@@ -56,36 +57,32 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
          * @method render
          */
         render: function () {
-            var props = Object.assign({}, {
-                i13n: {
-                    executeEvent: this.executeI13nEvent,
-                    getI13nNode: this.getI13nNode
-                }
-            }, this.props);
+            var self = this;
 
+            // filter props that's only meaningful for I13nComponent
+            var propsToFilter = {
+                i13nModel: true,
+                follow: true,
+                isLeafNode: true,
+                bindClickEvent: true,
+                scanLinks: true
+            };
+            var props = Object.keys(this.props).reduce(function reduceProps(propsMap, propName) {
+                if (!propsToFilter.hasOwnProperty(propName)) {
+                    propsMap[propName] = self.props[propName];
+                }
+                return propsMap;
+            }, {});
+            
             if (options.refToWrappedComponent) {
                 props.ref = options.refToWrappedComponent;
             }
-
-            // delete the props that only used in this level
-            props.i13nModel = undefined;
-
-            if (!componentIsFunction) {
-              // filter props to avoid to pass unknown props to components such <a> or <button>
-              var propsToFilter = {
-                  i13n: true,
-                  i13nModel: true,
-                  follow: true,
-                  isLeafNode: true,
-                  bindClickEvent: true,
-                  scanLinks: true
-              };
-              props = Object.keys(props).reduce(function reduceProps(propsMap, propName) {
-                  if (!propsToFilter.hasOwnProperty(propName)) {
-                    propsMap[propName] = props[propName];
-                  }
-                  return propsMap;
-              }, {});
+            
+            if (options.passUtilFunctionsByProps) {
+                props.i13n = {
+                    executeEvent: this.executeI13nEvent,
+                    getI13nNode: this.getI13nNode
+                };
             }
 
             return React.createElement(

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -8,6 +8,27 @@
 var React = require('react');
 var I13nMixin = require('../mixins/I13nMixin');
 var hoistNonReactStatics = require('hoist-non-react-statics');
+var PROPS_TO_FILTER = [
+    'bindClickEvent',
+    'follow',
+    'i13nModel',
+    'isLeafNode',
+    'scanLinks'
+];
+
+function objectWithoutProperties(obj, keys) {
+    var target = {};
+    for (var i in obj) {
+        if (keys.indexOf(i) >= 0) {
+            continue;
+        }
+        if (!Object.prototype.hasOwnProperty.call(obj, i)) {
+            continue;
+        }
+        target[i] = obj[i];
+    }
+    return target;
+}
 
 /**
  * createI13nNode higher order function to create a Component with I13nNode functionality
@@ -57,22 +78,8 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
          * @method render
          */
         render: function () {
-            var self = this;
-
-            // filter props that's only meaningful for I13nComponent
-            var propsToFilter = {
-                i13nModel: true,
-                follow: true,
-                isLeafNode: true,
-                bindClickEvent: true,
-                scanLinks: true
-            };
-            var props = Object.keys(this.props).reduce(function reduceProps(propsMap, propName) {
-                if (!propsToFilter.hasOwnProperty(propName)) {
-                    propsMap[propName] = self.props[propName];
-                }
-                return propsMap;
-            }, {});
+            // filter i13n related props
+            var props = objectWithoutProperties(this.props, PROPS_TO_FILTER);
             
             if (options.refToWrappedComponent) {
                 props.ref = options.refToWrappedComponent;

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -16,7 +16,7 @@ var hoistNonReactStatics = require('hoist-non-react-statics');
  * @param {Object} options
  * @param {String} options.displayName display name
  * @param {String} options.refToWrappedComponent ref name to wrapped component
- * @param {Boolean} options.passUtilFunctionsByProps true to allow i13n util function to be passed via props.i13n
+ * @param {Boolean} options.skipUtilFunctionsByProps true to prevent i13n util function to be passed via props.i13n
  * @method createI13nNode
  */
 module.exports = function createI13nNode (Component, defaultProps, options) {
@@ -78,7 +78,7 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
                 props.ref = options.refToWrappedComponent;
             }
             
-            if (options.passUtilFunctionsByProps) {
+            if (!options.skipUtilFunctionsByProps && componentIsFunction) {
                 props.i13n = {
                     executeEvent: this.executeI13nEvent,
                     getI13nNode: this.getI13nNode

--- a/src/utils/setupI13n.js
+++ b/src/utils/setupI13n.js
@@ -17,7 +17,7 @@ var IS_CLIENT = typeof window !== 'undefined';
  * @param {Object} options.rootModelData model data of root i13n node
  * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities
  * @param {Object} options.displayName display name of the wrapper component
- * @param {Boolean} options.passUtilFunctionsByProps true to allow i13n util function to be passed via props.i13n
+ * @param {Boolean} options.skipUtilFunctionsByProps true to prevent i13n util function to be passed via props.i13n
  * @param {Array} plugins plugins
  * @method setupI13n
  */
@@ -55,7 +55,7 @@ module.exports = function setupI13n (Component, options, plugins) {
 
         render: function () {
             var props = Object.assign({}, this.props);
-            if (options.passUtilFunctionsByProps) {
+            if (!options.skipUtilFunctionsByProps) {
                 props.i13n = {
                     executeEvent: this.executeI13nEvent,
                     getI13nNode: this.getI13nNode,

--- a/src/utils/setupI13n.js
+++ b/src/utils/setupI13n.js
@@ -17,6 +17,7 @@ var IS_CLIENT = typeof window !== 'undefined';
  * @param {Object} options.rootModelData model data of root i13n node
  * @param {Object} options.i13nNodeClass the i13nNode class, you can inherit it with your own functionalities
  * @param {Object} options.displayName display name of the wrapper component
+ * @param {Boolean} options.passUtilFunctionsByProps true to allow i13n util function to be passed via props.i13n
  * @param {Array} plugins plugins
  * @method setupI13n
  */
@@ -53,13 +54,14 @@ module.exports = function setupI13n (Component, options, plugins) {
         },
 
         render: function () {
-            var props = Object.assign({}, {
-                i13n: {
+            var props = Object.assign({}, this.props);
+            if (options.passUtilFunctionsByProps) {
+                props.i13n = {
                     executeEvent: this.executeI13nEvent,
                     getI13nNode: this.getI13nNode,
                     reactI13nInstance: this._reactI13nInstance
-                }
-            }, this.props);
+                };
+            }
             return React.createElement(
                 Component,
                 props,

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -257,7 +257,7 @@ describe('createI13nNode', function () {
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {scanLinks: {enable: true}}), container);
     });
 
-    it('should able to use props.getI13nNode to get the nearest i13n node', function () {
+    it('should able to use props.getI13nNode to get the nearest i13n node when passUtilFunctionsByProps is true', function () {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             render: function() {
@@ -270,12 +270,12 @@ describe('createI13nNode', function () {
         mockData.reactI13n.execute = function (eventName) {
         };
         mockData.isViewportEnabled = false;
-        var I13nTestComponent = createI13nNode(TestComponent);
+        var I13nTestComponent = createI13nNode(TestComponent, {}, {passUtilFunctionsByProps: true});
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {i13nModel: {foo: 'bar'}}), container);
     });
 
-    it('should able to use props.executeEvent to execute i13n event', function (done) {
+    it('should able to use props.executeEvent to execute i13n event when passUtilFunctionsByProps is true', function (done) {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             render: function() {
@@ -292,7 +292,7 @@ describe('createI13nNode', function () {
             }
         };
         mockData.isViewportEnabled = false;
-        var I13nTestComponent = createI13nNode(TestComponent);
+        var I13nTestComponent = createI13nNode(TestComponent, {}, {passUtilFunctionsByProps: true});
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {i13nModel: {foo: 'bar'}}), container);
     });
@@ -397,8 +397,32 @@ describe('createI13nNode', function () {
         var I13nTestComponent = createI13nNode(undefined);
         expect(I13nTestComponent).to.eql(undefined);
     });
+    
+    it('should not get any i13n related props on wrapped component by default', function (done) {
+        var TestComponent = React.createClass({
+            displayName: 'TestComponent',
+            contextTypes: {
+                i13n: React.PropTypes.object
+            },
+            render: function() {
+                expect(this.props.i13n).to.equal(undefined)
+                expect(this.props.i13nModal).to.equal(undefined)
+                expect(this.props.follow).to.equal(undefined)
+                expect(this.props.isLeafNode).to.equal(undefined)
+                expect(this.props.bindClickEvent).to.equal(undefined)
+                expect(this.props.scanLinks).to.equal(undefined)
+                done();
+                return React.createElement('div');
+            }
+        });
 
-    it('should get i13n util functions via both props and context', function (done) {
+        var I13nTestComponent = createI13nNode(TestComponent);
+        mockData.reactI13n.execute = function (eventName) {}
+        var container = document.createElement('div');
+        var component = ReactDOM.render(React.createElement(I13nTestComponent, {i13nModel: {sec: 'foo'}}), container);
+    });
+
+    it('should get i13n util functions via both props and context when passUtilFunctionsByProps is true', function (done) {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             contextTypes: {
@@ -417,7 +441,7 @@ describe('createI13nNode', function () {
         });
 
         // check the initial state is correct after render
-        var I13nTestComponent = createI13nNode(TestComponent);
+        var I13nTestComponent = createI13nNode(TestComponent, {}, {passUtilFunctionsByProps: true});
         mockData.reactI13n.execute = function (eventName) {
             // should get a created event
             expect(eventName).to.eql('created');

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -435,7 +435,6 @@ describe('createI13nNode', function () {
                 expect(this.context.i13n).to.be.an('object');
                 expect(this.context.i13n.executeEvent).to.be.a('function');
                 expect(this.context.i13n.getI13nNode).to.be.a('function');
-                done();
                 return React.createElement('div');
             }
         });
@@ -444,7 +443,9 @@ describe('createI13nNode', function () {
         var I13nTestComponent = createI13nNode(TestComponent, {});
         mockData.reactI13n.execute = function (eventName) {
             // should get a created event
+            console.log(eventName);
             expect(eventName).to.eql('created');
+            done();
         }
         expect(I13nTestComponent.displayName).to.eql('I13nTestComponent');
         var container = document.createElement('div');

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -257,7 +257,7 @@ describe('createI13nNode', function () {
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {scanLinks: {enable: true}}), container);
     });
 
-    it('should able to use props.getI13nNode to get the nearest i13n node when passUtilFunctionsByProps is true', function () {
+    it('should able to use props.getI13nNode to get the nearest i13n node', function () {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             render: function() {
@@ -270,12 +270,12 @@ describe('createI13nNode', function () {
         mockData.reactI13n.execute = function (eventName) {
         };
         mockData.isViewportEnabled = false;
-        var I13nTestComponent = createI13nNode(TestComponent, {}, {passUtilFunctionsByProps: true});
+        var I13nTestComponent = createI13nNode(TestComponent, {});
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {i13nModel: {foo: 'bar'}}), container);
     });
 
-    it('should able to use props.executeEvent to execute i13n event when passUtilFunctionsByProps is true', function (done) {
+    it('should able to use props.executeEvent to execute i13n event', function (done) {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             render: function() {
@@ -292,7 +292,7 @@ describe('createI13nNode', function () {
             }
         };
         mockData.isViewportEnabled = false;
-        var I13nTestComponent = createI13nNode(TestComponent, {}, {passUtilFunctionsByProps: true});
+        var I13nTestComponent = createI13nNode(TestComponent, {});
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {i13nModel: {foo: 'bar'}}), container);
     });
@@ -398,7 +398,7 @@ describe('createI13nNode', function () {
         expect(I13nTestComponent).to.eql(undefined);
     });
     
-    it('should not get any i13n related props on wrapped component by default', function (done) {
+    it('should not get any i13n related props on wrapped component if skipUtilFunctionsByProps=true', function (done) {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             contextTypes: {
@@ -416,13 +416,13 @@ describe('createI13nNode', function () {
             }
         });
 
-        var I13nTestComponent = createI13nNode(TestComponent);
+        var I13nTestComponent = createI13nNode(TestComponent, {}, {skipUtilFunctionsByProps: true});
         mockData.reactI13n.execute = function (eventName) {}
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestComponent, {i13nModel: {sec: 'foo'}}), container);
     });
 
-    it('should get i13n util functions via both props and context when passUtilFunctionsByProps is true', function (done) {
+    it('should get i13n util functions via both props and context', function (done) {
         var TestComponent = React.createClass({
             displayName: 'TestComponent',
             contextTypes: {
@@ -441,7 +441,7 @@ describe('createI13nNode', function () {
         });
 
         // check the initial state is correct after render
-        var I13nTestComponent = createI13nNode(TestComponent, {}, {passUtilFunctionsByProps: true});
+        var I13nTestComponent = createI13nNode(TestComponent, {});
         mockData.reactI13n.execute = function (eventName) {
             // should get a created event
             expect(eventName).to.eql('created');

--- a/tests/unit/utils/setupI13n.js
+++ b/tests/unit/utils/setupI13n.js
@@ -57,6 +57,9 @@ describe('setupI13n', function () {
     });
 
     afterEach(function () {
+        delete global.window;
+        delete global.document;
+        delete global.navigator;
         mockery.disable();
     });
 

--- a/tests/unit/utils/setupI13n.js
+++ b/tests/unit/utils/setupI13n.js
@@ -92,7 +92,7 @@ describe('setupI13n', function () {
         expect(I13nTestApp.displayName).to.eql('CustomName');
     });
 
-    it('should get i13n util functions via both props and context when passUtilFunctionsByProps is true', function (done) {
+    it('should get i13n util functions via both props and context', function (done) {
         var TestApp = React.createClass({
             displayName: 'TestApp',
             contextTypes: {
@@ -109,7 +109,24 @@ describe('setupI13n', function () {
                 return React.createElement('div');
             }
         });
-        var I13nTestApp = setupI13n(TestApp, {passUtilFunctionsByProps: true}, [mockData.plugin]);
+        var I13nTestApp = setupI13n(TestApp, [mockData.plugin]);
+        var container = document.createElement('div');
+        var component = ReactDOM.render(React.createElement(I13nTestApp), container);
+    });
+    
+    it('should not get i13n util functions via props if skipUtilFunctionsByProps=true', function (done) {
+        var TestApp = React.createClass({
+            displayName: 'TestApp',
+            contextTypes: {
+                i13n: React.PropTypes.object
+            },
+            render: function() {
+                expect(this.props.i13n).to.equal(undefined);
+                done();
+                return React.createElement('div');
+            }
+        });
+        var I13nTestApp = setupI13n(TestApp, {skipUtilFunctionsByProps: true}, [mockData.plugin]);
         var container = document.createElement('div');
         var component = ReactDOM.render(React.createElement(I13nTestApp), container);
     });

--- a/tests/unit/utils/setupI13n.js
+++ b/tests/unit/utils/setupI13n.js
@@ -92,7 +92,7 @@ describe('setupI13n', function () {
         expect(I13nTestApp.displayName).to.eql('CustomName');
     });
 
-    it('should get i13n util functions via both props and context', function (done) {
+    it('should get i13n util functions via both props and context when passUtilFunctionsByProps is true', function (done) {
         var TestApp = React.createClass({
             displayName: 'TestApp',
             contextTypes: {
@@ -109,8 +109,8 @@ describe('setupI13n', function () {
                 return React.createElement('div');
             }
         });
-        var I13nTestApp = setupI13n(TestApp, mockData.options, [mockData.plugin]);
+        var I13nTestApp = setupI13n(TestApp, {passUtilFunctionsByProps: true}, [mockData.plugin]);
         var container = document.createElement('div');
-        var component = ReactDOM.render(React.createElement(I13nTestApp, {}), container);
+        var component = ReactDOM.render(React.createElement(I13nTestApp), container);
     });
 });


### PR DESCRIPTION
@ericf @redonkulus @lingyan 

address #119 to fix the unknown props warning from react@15.x

previous we only filter the i13n related props for native tags, but we might still have case that the custom wrapped component needs to bypass all the props it gets to a native tag, for example [NavLink](https://github.com/yahoo/fluxible/blob/master/packages/fluxible-router/lib/NavLink.js)

`I13nComponent -> NavLink(this level needs to bypass all the props, so it's hard to it to filter i13n props) -> <a>`

provide a new `skipUtilFunctionsByProps` option to fix this issue.