### PR TITLE
filter out followLink

### DIFF
--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -11,6 +11,7 @@ var hoistNonReactStatics = require('hoist-non-react-statics');
 var PROPS_TO_FILTER = [
     'bindClickEvent',
     'follow',
+    'followLink',
     'i13nModel',
     'isLeafNode',
     'scanLinks'

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -80,6 +80,9 @@ module.exports = function createI13nNode (Component, defaultProps, options) {
          */
         render: function () {
             // filter i13n related props
+            if ('production' !== process.env.NODE_ENV && undefined !== this.props.followLink) {
+                console && console.warn && console.warn('props.followLink support is deprecated, please use props.follow instead.');
+            }
             var props = objectWithoutProperties(this.props, PROPS_TO_FILTER);
             
             if (options.refToWrappedComponent) {

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -40,6 +40,8 @@ var mockSubscribe = {
     }
 };
 var mockClickHandler = function () {};
+var oldWarn = console.warn;
+var oldTrace = console.trace;
 
 function findProps(elem) {
     try {
@@ -98,6 +100,8 @@ describe('createI13nNode', function () {
         delete global.document;
         delete global.navigator;
         mockery.disable();
+        console.warn = oldWarn;
+        console.trace = oldTrace;
     });
 
     it('should generate a component with createI13nNode', function (done) {
@@ -469,6 +473,9 @@ describe('createI13nNode', function () {
         var props = {
             i13nModel: {sec: 'foo'},
             href: '#/foobar'
+        };
+        console.warn = function (msg) {
+            expect(msg).to.equal('props.followLink support is deprecated, please use props.follow instead.');
         };
         var I13nTestComponent = createI13nNode('a', {
             follow: true,

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -472,6 +472,7 @@ describe('createI13nNode', function () {
         };
         var I13nTestComponent = createI13nNode('a', {
             follow: true,
+            followLink: true,
             isLeafNode: true,
             bindClickEvent: true,
             scanLinks: {enable: true}


### PR DESCRIPTION
@lingyan 

we use `followLink` as a hidden props to integrate with [NavLink](https://github.com/yahoo/fluxible/blob/master/packages/fluxible-router/lib/NavLink.js)

should filter it out as well

in this PR, also add a warning if user still have followLink usage. 
