### PR TITLE
support react lifecycle and static props for augment component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,11 @@
 {
   "env": {
     "test": {
-      "plugins": [ "istanbul" ]
+      "plugins": [
+        "istanbul",
+        "transform-es2015-modules-commonjs",
+        "transform-es2015-parameters"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,18 +15,21 @@
   "dependencies": {
     "debug": "^2.5.0",
     "hoist-non-react-statics": "^1.0.0",
+    "lodash": "^4.17.4",
     "setimmediate": "^1.0.2",
     "subscribe-ui-event": "^1.0.14"
   },
   "devDependencies": {
     "babel": "^6.5.2",
-    "babel-register": "^6.9.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-istanbul": "^3.1.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
+    "babel-plugin-transform-es2015-parameters": "^6.21.0",
     "babel-plugin-transform-react-jsx": "^6.22.0",
+    "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
-    "babel-polyfill": "^6.9.1",
+    "babel-register": "^6.9.0",
     "benchmark": "~2.1.3",
     "coveralls": "^2.11.14",
     "es5-shim": "^4.0.0",
@@ -54,6 +57,7 @@
     "promise": "^7.0.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
+    "sinon": "^1.17.7",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.3.0",
     "xunit-file": "~1.0.0"

--- a/src/utils/augmentComponent.js
+++ b/src/utils/augmentComponent.js
@@ -4,22 +4,65 @@
  */
 'use strict';
 
+import merge from 'lodash/merge';
+
+const REACT_LIFE_CYCLE_FUNCTIONS = {
+    componentDidMount: true,
+    componentDidUpdate: true,
+    componentWillMount: true,
+    componentWillReceiveProps: true,
+    componentWillUnmount: true,
+    componentWillUpdate: true,
+    shouldComponentUpdate: true
+};
+
+const REACT_STATIC_PROPS = {
+    childContextTypes: true,
+    contextTypes: true,
+    propTypes: true
+};
+
 /**
  * Add prototype/static properties to the target
- * please note that this is a helper function to generate the i13n component, just assign properties anyways instead of handling the React life cycle 
+ * NOTE: This util is used to provide a component with the i13n functionalities with ComponentSpec.js
+ * Which is a pure object to support BC of I13nMixin and I13nUtil
+ * For regular usage we will still suggest to use ES6 extends
  * @method augmentComponent
  * @param {Object} target React component
- * @param {Object} prototypeProps the prototype source to augment target
- * @param {Object} staticProps the static source to augment target
+ * @param {Object} prototypeProps the prototype source to augment target, if it's react lifecycle function then execute both original and new one
+ * @param {Object} staticProps the static source to augment target, if it's react static props then do a merge
  */
 module.exports = function augmentComponent(target, prototypeProps, staticProps) {
     prototypeProps = prototypeProps || {};
     staticProps = staticProps || {};
-    Object.getOwnPropertyNames(prototypeProps).forEach(function forEachProperty(name) {
+    Object.getOwnPropertyNames(prototypeProps).forEach((name) => {
         if (name !== "constructor") {
-            Object.defineProperty(target.prototype, name, Object.getOwnPropertyDescriptor(prototypeProps, name));
+            if (REACT_LIFE_CYCLE_FUNCTIONS[name]) {
+                let oldFunction = target.prototype[name];
+                if (oldFunction) {
+                    target.prototype[name] = (...args) => {
+                        // execute both except shouldComponentUpdate 
+                        if (name === 'shouldComponentUpdate') {
+                            return oldFunction.apply(this, args) && prototypeProps[name].apply(this, args);
+                        } else {
+                            oldFunction.apply(this, args);
+                            prototypeProps[name].apply(this, args);
+                        }
+                    };
+                } else {
+                    target.prototype[name] = prototypeProps[name];
+                }
+            } else {
+                Object.defineProperty(target.prototype, name, Object.getOwnPropertyDescriptor(prototypeProps, name));
+            }
         }
     });
-    Object.assign(target, staticProps);
+    Object.keys(staticProps).forEach((name) => {
+        if (REACT_STATIC_PROPS[name]) {
+            target[name] = merge(target[name], staticProps[name]);
+        } else {
+            target[name] = staticProps[name];
+        }
+    });
     return target;
-}
+};

--- a/tests/unit/utils/augmentComponent.js
+++ b/tests/unit/utils/augmentComponent.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* globals describe,it,document,beforeEach,afterEach */
+'use strict';
+
+/* All the functionalities are tested with this higher order component */
+
+import augmentComponent from '../../../src/utils/augmentComponent';
+import expect from 'expect.js';
+import sinon from 'sinon';
+import React from 'react';
+import ReactDOM from 'react-dom/server';
+        
+describe('augmentComponent', () => {
+    it('should be able add props to the original object', () => {
+        class Foo {
+            foo () {}
+        }
+        augmentComponent(Foo, {bar: () => null}, {baz: 'test'});
+        expect(Foo.baz).to.equal('test');
+        expect(Foo.prototype.bar).to.be.a('function')
+    });
+    
+    it('should be able add life cycle events to a React component', () => {
+        let fooComponentWillMount = sinon.stub();
+        let augmentedComponentWillMount = sinon.stub();
+        class FooComponent extends React.Component {
+            componentWillMount (...args) {
+                fooComponentWillMount.apply(this, args);
+            }
+            render () {
+                return null;
+            }
+        }
+        FooComponent.propTypes = {
+            foo: React.PropTypes.string
+        };
+        augmentComponent(FooComponent, {
+            componentWillMount: augmentedComponentWillMount
+        }, {
+            propTypes: {
+                bar: React.PropTypes.string
+            }
+        });
+        // check static props, should do a merge
+        expect(FooComponent.propTypes.foo).to.eql(React.PropTypes.string);
+        expect(FooComponent.propTypes.bar).to.eql(React.PropTypes.string);
+        ReactDOM.renderToString(React.createElement(FooComponent, {}));
+        // both componentWillMount should be called
+        expect(fooComponentWillMount.callCount).to.equal(1);
+        expect(augmentedComponentWillMount.callCount).to.equal(1);
+    });
+});


### PR DESCRIPTION
@redonkulus @lingyan update augmentComponent, for react life cycle functions, create a wrapper to execute both.

With this change, we will be able to add ComponentSpec to another react component, which defines a react life cycle.

for example

```js
class FooComponent extends React.Component {
    componentWillMount () {
        // ...
    }
    render () {
        // ...
    }
}

FooComponent.propTypes = {
    foo: React.PropTypes.string
};

augmentComponent(FooComponent, {componentWillMount: () => {
    // ... 
}, {
    propTypes: {
        bar: React.PropTypes.string
    }
}); 
```

both componentWillMount will be executed, propTypes should include both foo and bar, just like a mixin. 


I don't think it's a common pattern, typically we should use extends or HOC, but this helps us to use augmentComponent to integrate react-i13n to a component without creating an additional component if we really want to do it. Especially for i13n components, who are used everywhere in the page, we might still want to prevent generating a wrapper anyways regardless the overhead of HOC. 