### PR TITLE
Save some bytes by abstracting function

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function (grunt) {
                     main: './<%= project.functional %>/bootstrap.js'
                 },
                 output: {
-                    path: './<%= project.functional %>/'
+                    path: path.resolve('<%= project.functional %>')
                 },
                 module: {
                     rules: [

--- a/src/libs/DebugDashboard.js
+++ b/src/libs/DebugDashboard.js
@@ -10,11 +10,11 @@ var uniqueId = 0;
 
 var textColor = 'rgba(255,255,255,.87)';
 var baseItemStyle = {
-  color: textColor,
-  padding: '8px',
-  'white-space': 'nowrap',
-  overflow: 'hidden',
-  'text-overflow': 'ellipsis'
+    color: textColor,
+    padding: '8px',
+    'white-space': 'nowrap',
+    overflow: 'hidden',
+    'text-overflow': 'ellipsis'
 };
 
 function checkHidden (DOMNode) {
@@ -33,13 +33,13 @@ function checkHidden (DOMNode) {
 }
 
 function addStylesToNode (DOMNode, styles) {
-  Object.keys(styles).forEach(function addStyle(key) {
-    DOMNode.style[key] = styles[key];
-  });
+    Object.keys(styles).forEach(function addStyle(key) {
+        DOMNode.style[key] = styles[key];
+    });
 }
 
 function createNode (tag) {
-  return document.createElement(tag);
+    return document.createElement(tag);
 }
 
 function setupContainerPosition (DOMNode, container, dashboard) {
@@ -47,10 +47,10 @@ function setupContainerPosition (DOMNode, container, dashboard) {
     var left = offset.left + DOMNode.offsetWidth - 15;
 
     addStylesToNode(container, {
-      position: 'absolute',
-      'max-width': '300px',
-      top: offset.top + 'px',
-      'z-index': '10'
+        position: 'absolute',
+        'max-width': '300px',
+        top: offset.top + 'px',
+        'z-index': '10'
     });
 
     // adjust layout if dashboard is out of the viewport
@@ -108,17 +108,15 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
     }
     var dashboardContainer = createNode('ul');
     addStylesToNode(dashboardContainer, {
-      margin: 0,
-      'padding-left': 0,
-      'box-shadow': '0 1px 4px 0 rgba(0,0,0,.28)'
+        margin: 0,
+        'padding-left': 0,
+        'box-shadow': '0 1px 4px 0 rgba(0,0,0,.28)'
     });
 
     // compose title
     var dashboardTitle = createNode('li');
 
-    addStylesToNode(dashboardTitle, Object.assign({
-      background: '#673ab7'
-    }, baseItemStyle));
+    addStylesToNode(dashboardTitle, Object.assign({ background: '#673ab7' }, baseItemStyle));
 
     dashboardTitle.innerHTML = i13nNode.getText();
     dashboardContainer.appendChild(dashboardTitle);
@@ -129,8 +127,8 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
         var node = model[key].DOMNode;
 
         addStylesToNode(dashboardItem, Object.assign({
-          background: '#d1c4e9',
-          'border-top': '1px solid rgba(0,0,0,.12)',
+            background: '#d1c4e9',
+            'border-top': '1px solid rgba(0,0,0,.12)',
         }, baseItemStyle));
 
         dashboardItem.innerHTML = key + ' : ' + model[key].value + (node !== DOMNode ? ' (inherited)' : '');
@@ -150,14 +148,14 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
 
     // generate dashboard
     addStylesToNode(dashboard, {
-      position: 'relative',
-      display: 'none',
-      color: textColor,
-      fontsize: '14px',
-      width: '100%',
-      'margin-top': '2px',
-      'z-index': '1',
-      'border-radius': '2px'
+        position: 'relative',
+        display: 'none',
+        color: textColor,
+        fontsize: '14px',
+        width: '100%',
+        'margin-top': '2px',
+        'z-index': '1',
+        'border-radius': '2px'
     });
 
     dashboard.appendChild(dashboardContainer);
@@ -166,25 +164,25 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
     triggerNode.innerHTML = '&#8964;';
 
     addStylesToNode(triggerNode, {
-      background: '#673ab7',
-      color: textColor,
-      padding: '0 3px',
-      cursor: 'pointer'
+        background: '#673ab7',
+        color: textColor,
+        padding: '0 3px',
+        cursor: 'pointer'
     });
 
     self.clickListener = listen(triggerNode, 'click', function onClick() {
         if ('none' === dashboard.style.display) {
             addStylesToNode(dashboard, {
-              display: 'block',
-              'z-index': '12'
+                display: 'block',
+                'z-index': '12'
             });
             if (supportClassList) {
               container.classList.add('active');
             }
         } else {
             addStylesToNode(dashboard, {
-              display: 'none',
-              'z-index': '10'
+                display: 'none',
+                'z-index': '10'
             });
             if (supportClassList) {
               container.classList.remove('active');

--- a/src/libs/DebugDashboard.js
+++ b/src/libs/DebugDashboard.js
@@ -8,6 +8,15 @@ var listen = require('subscribe-ui-event').listen;
 var supportClassList = false;
 var uniqueId = 0;
 
+var textColor = 'rgba(255,255,255,.87)';
+var baseItemStyle = {
+  color: textColor,
+  padding: '8px',
+  'white-space': 'nowrap',
+  overflow: 'hidden',
+  'text-overflow': 'ellipsis'
+};
+
 function checkHidden (DOMNode) {
     if (DOMNode !== document) {
         var styles = window.getComputedStyle(DOMNode) || {};
@@ -23,21 +32,32 @@ function checkHidden (DOMNode) {
     }
 }
 
+function addStylesToNode (DOMNode, styles) {
+  Object.keys(styles).forEach(function addStyle(key) {
+    DOMNode.style[key] = styles[key];
+  });
+}
+
+function createNode (tag) {
+  return document.createElement(tag);
+}
+
 function setupContainerPosition (DOMNode, container, dashboard) {
     var offset = cumulativeOffset(DOMNode);
     var left = offset.left + DOMNode.offsetWidth - 15;
 
-    container.style.position = 'absolute';
-    container.style['max-width'] = '300px';
-    container.style.top = offset.top + 'px';
+    addStylesToNode(container, {
+      position: 'absolute',
+      'max-width': '300px',
+      top: offset.top + 'px',
+      'z-index': '10'
+    });
 
     // adjust layout if dashboard is out of the viewport
     if (left + 305 > window.innerWidth) {
         dashboard.style.left = (window.innerWidth - (left + 300) - 5) + 'px';
     }
-
     container.style.left = (offset.left + DOMNode.offsetWidth - 15) + 'px';
-    container.style['z-index'] = '10';
 }
 
 function cumulativeOffset (DOMNode) {
@@ -68,10 +88,10 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
     if (checkHidden(DOMNode)) {
         return;
     }
-    var container = document.createElement('div');
+    var container = createNode('div');
     container.id = 'i13n-debug-' + uniqueId;
-    var triggerNode = document.createElement('span');
-    var dashboard = document.createElement('div');
+    var triggerNode = createNode('span');
+    var dashboard = createNode('div');
     var model = i13nNode.getMergedModel(true);
 
     // check if browser support classList API
@@ -86,74 +106,86 @@ var DebugDashboard = function DebugDashboard (i13nNode) {
             DOMNode: DOMNode
         };
     }
-    var dashboardContainer = document.createElement('ul');
-    dashboardContainer.style.margin = 0;
-    dashboardContainer.style['padding-left'] = 0;
-    dashboardContainer.style['box-shadow'] = '0 1px 4px 0 rgba(0,0,0,.28)';
+    var dashboardContainer = createNode('ul');
+    addStylesToNode(dashboardContainer, {
+      margin: 0,
+      'padding-left': 0,
+      'box-shadow': '0 1px 4px 0 rgba(0,0,0,.28)'
+    });
 
     // compose title
-    var dashboardTitle = document.createElement('li');
-    dashboardTitle.style.background = '#673ab7';
-    dashboardTitle.style.color = 'rgba(255,255,255,.87)';
-    dashboardTitle.style.padding = '8px';
-    dashboardTitle.style['white-space'] = 'nowrap';
-    dashboardTitle.style['overflow'] = 'hidden';
-    dashboardTitle.style['text-overflow'] = 'ellipsis';
+    var dashboardTitle = createNode('li');
+
+    addStylesToNode(dashboardTitle, Object.assign({
+      background: '#673ab7'
+    }, baseItemStyle));
+
     dashboardTitle.innerHTML = i13nNode.getText();
     dashboardContainer.appendChild(dashboardTitle);
 
     // compose model items
     Object.keys(model).forEach(function generateModelInfo(key) {
-        var dashboardItem = document.createElement('li');
-        dashboardItem.style.background = '#d1c4e9';
-        dashboardItem.style.color = 'rgba(0,0,0,.87)';
-        dashboardItem.style['border-top'] = 'rgba(0,0,0,.12) 1px solid';
-        dashboardItem.style.padding = '8px';
-        dashboardItem.style['white-space'] = 'nowrap';
-        dashboardItem.style['overflow'] = 'hidden';
-        dashboardItem.style['text-overflow'] = 'ellipsis';
-        dashboardItem.innerHTML = key + ' : ' + model[key].value + (model[key].DOMNode !== DOMNode ? ' (inherited)' : '');
+        var dashboardItem = createNode('li');
+        var node = model[key].DOMNode;
+
+        addStylesToNode(dashboardItem, Object.assign({
+          background: '#d1c4e9',
+          'border-top': '1px solid rgba(0,0,0,.12)',
+        }, baseItemStyle));
+
+        dashboardItem.innerHTML = key + ' : ' + model[key].value + (node !== DOMNode ? ' (inherited)' : '');
 
         // set up scroll listener to show where the model data comes from
-        if (model[key].DOMNode) {
-            model[key].DOMNode.style.transition = 'border 0.05s';
+        if (node) {
+            node.style.transition = 'border 0.05s';
             self.modelItemsListener.push(listen(dashboardItem, 'mouseover', function mouseover() {
-                model[key].DOMNode.style.border = '4px solid #b39ddb';
+                node.style.border = '4px solid #b39ddb';
             }));
             self.modelItemsListener.push(listen(dashboardItem, 'mouseout', function mouseout() {
-                model[key].DOMNode.style.border = null;
+                node.style.border = null;
             }));
         }
         dashboardContainer.appendChild(dashboardItem);
     });
 
     // generate dashboard
-    dashboard.style.position = 'relative';
-    dashboard.style.display = 'none';
-    dashboard.style.color = 'rgba(255,255,255,.87)';
-    dashboard.style.fontsize = '14px';
-    dashboard.style.width = '100%';
-    dashboard.style['margin-top'] = '2px';
-    dashboard.style['z-index'] = '1';
-    dashboard.style['border-radius'] = '2px';
+    addStylesToNode(dashboard, {
+      position: 'relative',
+      display: 'none',
+      color: textColor,
+      fontsize: '14px',
+      width: '100%',
+      'margin-top': '2px',
+      'z-index': '1',
+      'border-radius': '2px'
+    });
+
     dashboard.appendChild(dashboardContainer);
 
     // generate trigger node
     triggerNode.innerHTML = '&#8964;';
-    triggerNode.style.background = '#673ab7';
-    triggerNode.style.color = 'rgba(255,255,255,.87)';
-    triggerNode.style.padding = '0 3px';
-    triggerNode.style.cursor = 'pointer';
+
+    addStylesToNode(triggerNode, {
+      background: '#673ab7',
+      color: textColor,
+      padding: '0 3px',
+      cursor: 'pointer'
+    });
+
     self.clickListener = listen(triggerNode, 'click', function onClick() {
         if ('none' === dashboard.style.display) {
-            dashboard.style.display = 'block';
-            container.style['z-index'] = '11';
+            addStylesToNode(dashboard, {
+              display: 'block',
+              'z-index': '12'
+            });
             if (supportClassList) {
               container.classList.add('active');
             }
         } else {
-            dashboard.style.display = 'none';
-            container.style['z-index'] = '10';
+            addStylesToNode(dashboard, {
+              display: 'none',
+              'z-index': '10'
+            });
             if (supportClassList) {
               container.classList.remove('active');
             }

--- a/tests/functional/bootstrap.js
+++ b/tests/functional/bootstrap.js
@@ -5,6 +5,7 @@ window.Object.assign = require('object-assign');
 
 window.React = require('react');
 window.ReactDOM = require('react-dom');
+window.createClass = require('create-react-class');
 
 window.I13nMixin = require('../../dist/mixins/I13nMixin');
 window.ReactI13n = require('../../dist/libs/ReactI13n');

--- a/tests/functional/i13n-functional.jsx
+++ b/tests/functional/i13n-functional.jsx
@@ -193,7 +193,7 @@ var testPlugin = {
 try {
 I13nDemo = setupI13n(I13nDemo,
     {
-        isViewportEnabled: false,
+        isViewportEnabled: true,
         rootModelData: {
             sec: 'default-section-name',
             page: 'test-page'

--- a/tests/functional/i13n-functional.jsx
+++ b/tests/functional/i13n-functional.jsx
@@ -18,7 +18,7 @@ function getJsonFromUrl() {
 var container = document.getElementById('container');
 var itemsNumber = getJsonFromUrl().items || 1;
 
-var I13nComponentLevel1 = React.createClass({
+var I13nComponentLevel1 = createClass({
     render: function () {
         var links = [];
         for (var i = 0; i < itemsNumber; i++) {
@@ -81,7 +81,7 @@ var I13nComponentLevel1 = React.createClass({
 
 I13nComponentLevel1 = createI13nNode(I13nComponentLevel1);
 
-var I13nComponentLevel2 = React.createClass({
+var I13nComponentLevel2 = createClass({
     render: function () {
         var links = [];
         for (var i = 0; i < itemsNumber; i++) {
@@ -104,7 +104,7 @@ var I13nComponentLevel2 = React.createClass({
 
 I13nComponentLevel2 = createI13nNode(I13nComponentLevel2);
 
-var I13nComponentLevel2Hidden = React.createClass({
+var I13nComponentLevel2Hidden = createClass({
     getInitialState: function () {
         return {
             expend: false
@@ -137,7 +137,7 @@ var I13nComponentLevel2Hidden = React.createClass({
 
 I13nComponentLevel2Hidden = createI13nNode(I13nComponentLevel2Hidden);
 
-var I13nDemo = React.createClass({
+var I13nDemo = createClass({
     componentWillMount: function () {
         ReactI13n.getInstance().execute('pageview', {});
     },
@@ -193,7 +193,7 @@ var testPlugin = {
 try {
 I13nDemo = setupI13n(I13nDemo,
     {
-        isViewportEnabled: true,
+        isViewportEnabled: false,
         rootModelData: {
             sec: 'default-section-name',
             page: 'test-page'


### PR DESCRIPTION
This PR aims to reduce some bytes of `DebugDashboard`

The `DebugDashboard` consist quite some size in our bundle.

discussed with @kaesonho, ideally we should defer/lazy load the dashboard as its not critical.
However, not all user using webpack (`require.ensure` or `import`) so we cannot just directly change the source code.

the other way is to generate one javascript file and add script tag programmatically when enable, but it will requires some work on webpack to generate a compiled file.

This PR just simply abstract some function to reduce bytes.