### PR TITLE
Remove target.href from href assignment

### DIFF
--- a/src/libs/clickHandler.js
+++ b/src/libs/clickHandler.js
@@ -67,7 +67,7 @@ module.exports = function clickHandler (e) {
         return;
     }
 
-    href = props.href || target.href;
+    href = props.href;
 
     // if users disable the redirect by follow, force set it as false
     if (undefined !== followLink) {


### PR DESCRIPTION
This pull request addresses issue #174, where clicks on routed links (using redux and react-router) are causing page reloads.

It looks like the addition of the `|| target.href` may have been added by mistake during the refactor on 2/8/2017 (d003934c29ccc89fe488557690917f8ecb88f6eb), but I could be wrong.  If it actually is needed then this fix won't work.

The way it was previously (`href = props.href`) is fine for both routed and normal links (normal 'a' elements wrapped with i13n).  When wrapping a normal 'a' element, we do get the href from `props.href`, so everything functions as expected.

The problem here with react-router is that `target.href` exists for the routed link, but `props.href` does not.  So we end up with a situation where the routed link gets treated like a normal link (and the app no longer behaves as a single-page app).

Removing the `|| target.href` fixes the issue for the project I'm working on and the example I posted [here](https://github.com/ebertb/react-redux-starter-kit) and I didn't see any unintended side effects.  Hopefully I'm not missing anything.