### PR TITLE
Force dependency for security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "grunt cover"
   },
   "dependencies": {
-    "debug": "^3.0.0",
+    "debug": "^3.1.0",
     "hoist-non-react-statics": "^2.0.0",
     "prop-types": "^15.5.10",
     "setimmediate": "^1.0.2",


### PR DESCRIPTION
https://github.com/visionmedia/debug/issues/501 

Force minimal requirement to 3.1.0 to prevent security issue