### PR TITLE
Support i13n dashboard update when component update

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "debug": "^3.1.0",
     "hoist-non-react-statics": "^2.0.0",
     "prop-types": "^15.5.10",
-    "setimmediate": "^1.0.2",
     "subscribe-ui-event": "^1.0.14"
   },
   "devDependencies": {

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -5,8 +5,6 @@
 /* globals location */
 'use strict';
 
-require('setimmediate');
-
 var DebugDashboard = require('./DebugDashboard');
 var I13nNode = require('./I13nNode');
 var PropTypes = require('prop-types');
@@ -166,9 +164,7 @@ var prototypeSpecs = {
         }
 
         if (IS_DEBUG_MODE) {
-            setImmediate(function asyncShowDebugDashboard() {
-                self._debugDashboard = new DebugDashboard(self._i13nNode);
-            });
+            self._debugDashboard = new DebugDashboard(self._i13nNode);
         }
     },
 

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -173,6 +173,17 @@ var prototypeSpecs = {
     },
 
     /**
+     * componentDidUpdate
+     * @method componentWillMount
+     */
+    componentDidUpdate() {
+      if (IS_DEBUG_MODE) {
+        this._debugDashboard && this._debugDashboard.destroy();
+        this._debugDashboard = new DebugDashboard(this._i13nNode);
+      }
+    },
+
+    /**
      * componentWillMount
      * @method componentWillMount
      */

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -174,7 +174,7 @@ var prototypeSpecs = {
 
     /**
      * componentDidUpdate
-     * @method componentWillMount
+     * @method componentDidUpdate
      */
     componentDidUpdate() {
       if (IS_DEBUG_MODE) {

--- a/src/libs/DebugDashboard.js
+++ b/src/libs/DebugDashboard.js
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 /* global document, window*/
-var listen = require('subscribe-ui-event').listen;
+var listen = require('subscribe-ui-event/dist/lib/listen');
 
 var supportClassList = false;
 var uniqueId = 0;


### PR DESCRIPTION
@kaesonho @redonkulus 

Support i13n debug dashboard update if component update.

Also remove `setImmediate` timeout as it will complicate the update logic - if a component mounted and immediately update, the `destroy` function from `componentDidUpdate` will be called before the dashboard creation in `componentDidMount`, which is less then ideal.

As this is just an debug feature, I don't think we need to make it async to show the dashboard.