### PR TITLE
Fix CJS default export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "env": {
     "plugins": [
       "dynamic-import-node",
-      "syntax-dynamic-import"
+      "syntax-dynamic-import",
+      "add-module-exports"
     ],
     "test": {
       "presets": [

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 results/
 node_modules/
 dist/
+dist-es/
 *.log
 *.tap
 tests/functional/main.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
   const projectConfig = {
     src: 'src',
     dist: 'dist',
-    distES: 'dist/es',
+    distES: 'dist-es',
     unit: 'tests/unit',
     functional: 'tests/functional',
     spec: 'tests/spec',
@@ -84,7 +84,7 @@ module.exports = function (grunt) {
       dist: {
         options: {
           sourceMap: false,
-          plugins: ['dynamic-import-node', 'syntax-dynamic-import'],
+          plugins: ['dynamic-import-node', 'syntax-dynamic-import', 'add-module-exports'],
           presets: [
             [
               'env',
@@ -109,7 +109,7 @@ module.exports = function (grunt) {
       'dist-es': {
         options: {
           sourceMap: false,
-          plugins: ['dynamic-import-node', 'syntax-dynamic-import'],
+          plugins: ['dynamic-import-node', 'syntax-dynamic-import', 'add-module-exports'],
           presets: [
             [
               'env',

--- a/index.es.js
+++ b/index.es.js
@@ -3,15 +3,15 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-import I13nNodeLib from './dist/es/libs/I13nNode';
-import ReactI13nLib from './dist/es/libs/ReactI13n';
+import I13nNodeLib from './dist-es/libs/I13nNode';
+import ReactI13nLib from './dist-es/libs/ReactI13n';
 
-import createI13nNodeLib from './dist/es/utils/createI13nNode';
-import setupI13nLib from './dist/es/utils/setupI13n';
+import createI13nNodeLib from './dist-es/utils/createI13nNode';
+import setupI13nLib from './dist-es/utils/setupI13n';
 
-import I13nAnchorLib from './dist/es/components/I13nAnchor';
-import I13nButtonLib from './dist/es/components/I13nButton';
-import I13nDivLib from './dist/es/components/I13nDiv';
+import I13nAnchorLib from './dist-es/components/I13nAnchor';
+import I13nButtonLib from './dist-es/components/I13nButton';
+import I13nDivLib from './dist-es/components/I13nDiv';
 
 // Core libraries
 export var I13nNode = I13nNodeLib;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i13n",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1085,6 +1085,15 @@
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-add-module-exports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.0.tgz",
+      "integrity": "sha512-m0sMxPL4FaN2K69GQgaRJa4Ny15qKSdoknIcpN+gz+NaJlAW9pge/povs13tPYsKDboflrEQC+/3kfIsONBTaw==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.0.4"
       }
     },
     "babel-plugin-check-es2015-constants": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {
@@ -27,6 +27,7 @@
     "babel": "^6.5.2",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
+    "babel-plugin-add-module-exports": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-react-jsx": "^6.22.0",

--- a/tests/functional/bootstrap.js
+++ b/tests/functional/bootstrap.js
@@ -10,10 +10,10 @@ window.ReactDOM = require('react-dom');
 // TODO, this should be deprecated
 window.createClass = require('create-react-class');
 
-window.I13nAnchor = require('../../dist/components/I13nAnchor').default;
-window.I13nButton = require('../../dist/components/I13nButton').default;
-window.I13nDiv = require('../../dist/components/I13nDiv').default;
+window.I13nAnchor = require('../../dist/components/I13nAnchor');
+window.I13nButton = require('../../dist/components/I13nButton');
+window.I13nDiv = require('../../dist/components/I13nDiv');
 
-window.createI13nNode = require('../../dist/utils/createI13nNode').default;
-window.clickHandler = require('../../dist/libs/clickHandler').default;
-window.setupI13n = require('../../dist/utils/setupI13n').default;
+window.createI13nNode = require('../../dist/utils/createI13nNode');
+window.clickHandler = require('../../dist/libs/clickHandler');
+window.setupI13n = require('../../dist/utils/setupI13n');

--- a/tests/unit/libs/DebugDashboard.js
+++ b/tests/unit/libs/DebugDashboard.js
@@ -21,7 +21,7 @@ describe('clickHandler', () => {
     global.requestAnimationFrame = function (callback) {
       setTimeout(callback, 0);
     };
-    DebugDashboard = require('../../../dist/libs/DebugDashboard').default;
+    DebugDashboard = require('../../../dist/libs/DebugDashboard');
   });
 
   afterEach(() => {

--- a/tests/unit/utils/createI13nNode.js
+++ b/tests/unit/utils/createI13nNode.js
@@ -85,8 +85,8 @@ describe('createI13nNode', () => {
     mockery.registerMock('subscribe-ui-event', mockSubscribe);
     mockery.registerMock('../libs/clickHandler', mockClickHandler);
 
-    createI13nNode = require('../../../dist/utils/createI13nNode').default;
-    I13nNode = require('../../../dist/libs/I13nNode').default;
+    createI13nNode = require('../../../dist/utils/createI13nNode');
+    I13nNode = require('../../../dist/libs/I13nNode');
 
     rootI13nNode = new I13nNode(null, {});
     mockData.reactI13n = {

--- a/tests/unit/utils/setupI13n.js
+++ b/tests/unit/utils/setupI13n.js
@@ -60,7 +60,7 @@ describe('setupI13n', () => {
 
     mockery.registerMock('../libs/ReactI13n', MockReactI13n);
 
-    setupI13n = require('../../../dist/utils/setupI13n').default;
+    setupI13n = require('../../../dist/utils/setupI13n');
   });
 
   afterEach(() => {


### PR DESCRIPTION
1. Add default export to cjs module
1. change export folder for `es` module to `dist-es` to better manage the folder.