### PR TITLE
Correct static method and module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0-alpha.4",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.3",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -13,9 +13,9 @@ import I13nNode from './I13nNode';
 import warnAndPrintTrace from '../utils/warnAndPrintTrace';
 import isUndefined from '../utils/isUndefined';
 import { IS_CLIENT, IS_PROD } from '../utils/variables';
+import ViewportDetector from './ViewportDetector';
 
 const debug = require('debug')('I13nComponent');
-const ViewportDetector = require('./ViewportDetector');
 
 const IS_DEBUG_MODE = (function isDebugMode() {
   if (!IS_CLIENT) {

--- a/src/libs/ReactI13n.js
+++ b/src/libs/ReactI13n.js
@@ -51,7 +51,7 @@ class ReactI13n {
    * @method getInstance
    * @return the ReactI13n instance
    */
-  getInstance() {
+  static getInstance() {
     if (IS_CLIENT) {
       return window._reactI13nInstance;
     }

--- a/src/libs/ViewportDetector.js
+++ b/src/libs/ViewportDetector.js
@@ -103,4 +103,4 @@ ViewportDetector.prototype.isEnteredViewport = function () {
   return this._enteredViewport;
 };
 
-module.exports = ViewportDetector;
+export default ViewportDetector;

--- a/tests/functional/bootstrap.js
+++ b/tests/functional/bootstrap.js
@@ -10,10 +10,10 @@ window.ReactDOM = require('react-dom');
 // TODO, this should be deprecated
 window.createClass = require('create-react-class');
 
-window.I13nAnchor = require('../../dist/components/I13nAnchor');
-window.I13nButton = require('../../dist/components/I13nButton');
-window.I13nDiv = require('../../dist/components/I13nDiv');
+window.I13nAnchor = require('../../index').I13nAnchor;
+window.I13nButton = require('../../index').I13nButton;
+window.I13nDiv = require('../../index').I13nDiv;
 
-window.createI13nNode = require('../../dist/utils/createI13nNode');
+window.createI13nNode = require('../../index').createI13nNode;
+window.setupI13n = require('../../index').setupI13n;
 window.clickHandler = require('../../dist/libs/clickHandler');
-window.setupI13n = require('../../dist/utils/setupI13n');


### PR DESCRIPTION
1. `getInstance` is a static method instead of member function
1. Fix ViewportDetector module exports
1. Change test to load from index so we can catch build issue 