### PR TITLE
Remove create-react-class

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ module.exports = function (grunt) {
     watch: {
       functional: {
         files: ['<%= project.src%>/*.jsx', '<%= project.functional%>/*.jsx', '<%= project.functional%>/*.html'],
-        tasks: ['dist', 'functional-debug']
+        tasks: ['functional-debug']
       }
     },
     'saucelabs-mocha': {

--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ var I13nAnchor = createI13nNode('a', {
     follow: true
 });
 
-var DemoApp = React.createClass({
+class DemoApp extends React.Component {
     componentWillMount: function () {
         this.props.i13n.executeEvent('pageview', {}); // fire a custom event
-    },
+    }
     render: function () {
         ...
         <I13nAnchor href="http://foo.bar" i13nModel={{action: 'click', label: 'foo'}}>...</I13nAnchor>
         // this link will be tracked, and the click event handlers provided by the plugin will get the model data as
         // {site: 'foo', action: 'click', label: 'foo'}
     }
-});
+};
 
 var I13nDempApp = setupI13n(DemoApp, {
     rootModelData: {site: 'foo'},

--- a/docs/api/setupI13n.md
+++ b/docs/api/setupI13n.md
@@ -1,6 +1,6 @@
 ## setupI13n
 
-We provide `setupI13n` as a convenient [higher order function](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to setup the ReactI13n, you will need to pass your `top level component`, `options`, and `plugins` into it. This takes care of creating a `ReactI13n` instance and setting up the plugins. 
+We provide `setupI13n` as a convenient [higher order function](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to setup the ReactI13n, you will need to pass your `top level component`, `options`, and `plugins` into it. This takes care of creating a `ReactI13n` instance and setting up the plugins.
 
  * `Component` - the top level application component.
  * `options` - the options passed into ReactI13n.
@@ -16,7 +16,7 @@ var React = require('react');
 var setupI13n = require('react-i13n').setupI13n;
 var someReactI13nPlugin = require('some-react-i13n-plugin');
 
-var DemoApp = React.createClass({
+class DemoApp extends React.Component({
     ...
 });
 
@@ -31,7 +31,7 @@ var I13nDempApp = setupI13n(DemoApp, {
 
 ### Create and access the ReactI13n instance
 
-What we do with `setupI13n` is that we will create the `ReactI13n` instance, along with a root node of the I13nTree, passing them via component context to the children. 
+What we do with `setupI13n` is that we will create the `ReactI13n` instance, along with a root node of the I13nTree, passing them via component context to the children.
 
 It's designed to work within React components, you should be able to just use [utilFuctions](https://github.com/yahoo/react-i13n/blob/master/docs/guides/utilFunctions.md) and trigger i13n events. In case you want to do this out of React components, you can access `window._reactI13nInstance` directly.
 

--- a/docs/guides/eventSystem.md
+++ b/docs/guides/eventSystem.md
@@ -33,15 +33,15 @@ var fooPlugin = {
     }
 }
 
-var Foo = React.createClass({
-    componentWillMount: function () {
+class Foo extends React.Component {
+    componentWillMount () {
         // whenever you define a event handler, you can fire an event for that.
         this.props.i13n.executeEvent('customEvent', {payload}, function beaconCallback () {
             // do whatever after beaconing
         });
     }
     ...
-});
+};
 
 var I13nFoo = setupI13n(Foo, {}, [fooPlugin]);
 

--- a/docs/guides/integrateWithComponents.md
+++ b/docs/guides/integrateWithComponents.md
@@ -7,32 +7,38 @@ This guide will show you how to take an existing component and modify it to leve
 Say you have a video player component and you want to track each link, you might need to have `onClick` for each links, for example:
 
 ```js
-var Player = React.createClass({
-    ...
-    render: function () {
-        trackButton: function (category, action) {
-            // assume "beacon" is some beaconing function
-            beacon(category, action);
-        },
-        trackExternalLink: function (category, action, url) {
-            // typically you will redirect users to the destination page after beaconing
-            beacon(category, action, function onBeaconFinish() {
-                document.location = url;
-            });
-        },
-        return (
-            <div>
-                ...
-                <button onClick="this.trackButton('VideoPlayer', 'Play')">Play</button>
-                <button onClick="this.trackButton('VideoPlayer', 'Download')">Download</button>
-                <a onClick="this.trackExternalLink('VideoPlayer', 'More', 'http://some.more.link')" href="http://some.more.link">More</a>
-            </div>
-        )
-    }
-});
+class Player extends React.Component {
+  trackButton = (category, action) => {
+    // assume "beacon" is some beaconing function
+    beacon(category, action);
+  };
+
+  trackExternalLink = (category, action, url) => {
+    // typically you will redirect users to the destination page after beaconing
+    beacon(category, action, function onBeaconFinish() {
+      document.location = url;
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        ...
+        <button onClick="this.trackButton('VideoPlayer', 'Play')">Play</button>
+        <button onClick="this.trackButton('VideoPlayer', 'Download')">Download</button>
+        <a
+          onClick="this.trackExternalLink('VideoPlayer', 'More', 'http://some.more.link')"
+          href="http://some.more.link"
+        >
+          More
+        </a>
+      </div>
+    );
+  }
+}
 
 // in some other component
-<Player></Player>
+<Player></Player>;
 ```
 
 ### Replace with I13n Components
@@ -51,9 +57,9 @@ var I13nButton = createI13nNode('button', {
     bindClickEvent: true,
     follow: false // it's only interaction here, we don't want to redirect users to the destination page, set it as false
 });
-var Player = React.createClass({
+class Player extends React.Component {
     ...
-    render: function () {
+    render() {
         return (
             <div>
                 ...
@@ -63,7 +69,7 @@ var Player = React.createClass({
             </div>
         )
     }
-});
+};
 
 // in some other component
 <Player></Player>
@@ -87,9 +93,9 @@ var I13nButton = createI13nNode('button', {
     bindClickEvent: true,
     follow: false
 });
-var Player = React.createClass({
+class Player extends React.Component {
     ...
-    render: function () {
+    render() {
         return (
             <div>
                 ...
@@ -99,7 +105,7 @@ var Player = React.createClass({
             </div>
         )
     }
-});
+};
 
 Player = createI13nNode(Player);
 
@@ -108,7 +114,6 @@ Player = createI13nNode(Player);
 ```
 
 The player component is now an i13nNode and you can pass i13nModel here, all the links inside will apply this model data.
-
 
 ### Dynamic I13n Model
 
@@ -126,15 +131,15 @@ var I13nButton = createI13nNode('button', {
     bindClickEvent: true,
     follow: false
 });
-var Player = React.createClass({
+class Player extends React.Component {
     ...
-    getPlayI13nModel: function () {
+    getPlayI13nModel() {
         return {
             action: 'Play',
             label: this.getVideoTitle();
         }
-    },
-    render: function () {
+    };
+    render() {
         return (
             <div>
                 ...
@@ -144,7 +149,7 @@ var Player = React.createClass({
             </div>
         )
     }
-});
+};
 
 Player = createI13nNode(Player);
 
@@ -156,25 +161,23 @@ Player = createI13nNode(Player);
 
 Sometimes you just want to group links in your template instead of creating a component with i13n functionalities, you can create a simple component and pass `i13nModel` data directly. This way, you can easily group links with some shared i13n data definition.
 
-* Please note that since we integrate the feature of `parent-based context`, with `dev` env, react will generate warning like
+- Please note that since we integrate the feature of `parent-based context`, with `dev` env, react will generate warning like
 
 ```js
 Warning: owner-based and parent-based contexts differ (values: [object Object] vs [object Object]) for key (parentI13nNode) while mounting I13nAnchor (see: http://fb.me/react-context-by-parent)
 ```
 
-* This feature can only be used after `react-0.13`, if you are using an older version, you will have to create the component as mentioned above [example](#integrate-with-parent-nodes).
+- This feature can only be used after `react-0.13`, if you are using an older version, you will have to create the component as mentioned above [example](#integrate-with-parent-nodes).
 
 ```js
 var createI13nNode = require('react-i13n').createI13nNode;
 var I13nDiv = createI13nNode('div', {
-    isLeafNode: false,
-    bindClickEvent: false,
-    follow: false
+  isLeafNode: false,
+  bindClickEvent: false,
+  follow: false
 });
 
-<I13nDiv i13nModel={parentI13nModel}>
-    // the i13n node inside will inherit the model data of its parent
-</I13nDiv>
+<I13nDiv i13nModel={parentI13nModel}>// the i13n node inside will inherit the model data of its parent</I13nDiv>;
 ```
 
 ```js
@@ -197,15 +200,15 @@ var I13nDiv = createI13nNode('div', {
     follow: false
 });
 
-var Player = React.createClass({
+class Player extends React.Component {
     ...
-    getPlayI13nModel: function () {
+    getPlayI13nModel() {
         return {
             action: 'Play',
             label: this.getVideoTitle();
         }
-    },
-    render: function () {
+    };
+    render() {
         return (
             <I13nDiv i13nModel={{category: 'VideoPlayer'}}>
                 ...
@@ -215,7 +218,7 @@ var Player = React.createClass({
             </I13nDiv>
         )
     }
-});
+};
 
 // in some other component
 <Player></Player>
@@ -225,8 +228,8 @@ var Player = React.createClass({
 
 For common usage, the following components are available, you can require them without generating them every time. These setting can be overwritten by `props`.
 
-| Component | isLeafNode | bindClickEvent | follow |
-| --------- | ---------- | -------------- | -------- |
-| **I13nAnchor** | true | true | true |
-| **I13nButton** | true | true | true |
-| **I13nDiv** | false | false | false |
+| Component      | isLeafNode | bindClickEvent | follow |
+| -------------- | ---------- | -------------- | ------ |
+| **I13nAnchor** | true       | true           | true   |
+| **I13nButton** | true       | true           | true   |
+| **I13nDiv**    | false      | false          | false  |

--- a/docs/guides/utilFunctions.md
+++ b/docs/guides/utilFunctions.md
@@ -7,13 +7,13 @@ We provides util functions for you to easily access the resource provided by `re
 
 ```js
 // with setupI13n or createI13nNode, you will automatically get this.props.i13n for i13n util functions
-var DemoComponent = React.createClass({
-  displayName: 'DemoComponent',
+class DemoComponent extends React.Component {
+  displayName = 'DemoComponent';
   render: function() {
     // this.props.i13n.getI13nNode() to access the i13nNode created by createI13nNode
     // this.props.i13n.executeEvent() to execute i13n event
   }
-});
+};
 
 var I13nDemoComponent = createI13nNode(DemoComponent);
 ```
@@ -21,11 +21,11 @@ var I13nDemoComponent = createI13nNode(DemoComponent);
 ```js
 
 // For components without `setupI13n` and `createI13nNode`, you can still get i13n functions via context
-var DemoComponent = React.createClass({
-    displayName: 'DemoComponent',
-    contextTypes: {
+class DemoComponent extends React.Component {
+    displayName = 'DemoComponent',;
+    contextTypes = {
         i13n: React.PropTypes.object
-    }
+    };
     render: function() {
         // this.context.i13n.getI13nNode() to access the nearest i13nNode created by createI13nNode
         // this.context.i13n.executeEvent() to execute i13n event
@@ -46,7 +46,7 @@ execute the i13n event, so that you don't need to call `ReactI13n.getInstance().
 import React, { Component } from 'react';
 
 class DemoComponent extends Component {
-  componentDidMount: function() {
+  componentDidMount() {
     // executeEvent will find the i13nNode and append to the payload for you, which means the final payload will be the i13nNode plus the payload you defined,
     // i.e., { i13nNode: [theI13nNode], foo: 'bar' }
     this.props.i13n.executeEvent('someEventName', { foo: 'bar' },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "benchmark": "^2.1.3",
-    "create-react-class": "^15.6.3",
     "es5-shim": "^4.5.12",
     "eslint": "^7.0.0",
     "eslint-config-airbnb": "^17.1.0",

--- a/tests/benchmark/benchmark.js
+++ b/tests/benchmark/benchmark.js
@@ -1,18 +1,16 @@
 /* start with benchmark */
 const { Suite } = require('benchmark');
-const createClass = require('create-react-class');
 const { renderToString } = require('react-dom/server');
-const { createElement } = require('react');
+const { createElement, Component } = require('react');
 const createI13nNode = require('../../dist/utils/createI13nNode').default;
 const I13nAnchor = require('../../dist/components/I13nAnchor').default;
 const I13nButton = require('../../dist/components/I13nButton').default;
 
-const PureReactComponent = createClass({
-  autobind: false,
+class PureReactComponent extends Component {
   render() {
     return createElement('a', this.props, this.props.children);
   }
-});
+};
 
 const createLinkChildren = function (Element, count) {
   const links = [];

--- a/tests/functional/bootstrap.js
+++ b/tests/functional/bootstrap.js
@@ -3,7 +3,6 @@
 /* global window */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import createClass from 'create-react-class';
 
 import {
   createI13nNode,
@@ -24,8 +23,6 @@ if (!Object.assign) {
 
 window.React = React;
 window.ReactDOM = ReactDOM;
-// TODO, this should be deprecated
-window.createClass = createClass;
 
 window.I13nAnchor = I13nAnchor;
 window.I13nButton = I13nButton;

--- a/tests/functional/i13n-functional.jsx
+++ b/tests/functional/i13n-functional.jsx
@@ -1,6 +1,5 @@
 /* global document, React, ReactDOM */
 
-
 function getJsonFromUrl() {
   const query = location.search.substr(1);
   const result = {};
@@ -17,7 +16,7 @@ function getJsonFromUrl() {
 const container = document.getElementById('container');
 const itemsNumber = getJsonFromUrl().items || 1;
 
-let I13nComponentLevel1 = createClass({
+class I13nComponentLevel1 extends React.Component {
   render() {
     const links = [];
     for (let i = 0; i < itemsNumber; i++) {
@@ -107,11 +106,11 @@ let I13nComponentLevel1 = createClass({
       </div>
     );
   }
-});
+}
 
 I13nComponentLevel1 = createI13nNode(I13nComponentLevel1);
 
-let I13nComponentLevel2 = createClass({
+class I13nComponentLevel2 extends React.Component {
   render() {
     const links = [];
     for (let i = 0; i < itemsNumber; i++) {
@@ -132,19 +131,19 @@ let I13nComponentLevel2 = createClass({
       </div>
     );
   }
-});
+}
 
 I13nComponentLevel2 = createI13nNode(I13nComponentLevel2);
 
-let I13nComponentLevel2Hidden = createClass({
-  getInitialState() {
-    return {
-      expend: false
-    };
-  },
-  clickHandler(e) {
+class I13nComponentLevel2Hidden extends React.Component {
+  state = {
+    expend: false
+  };
+
+  clickHandler = () => {
     this.setState({ expend: true });
-  },
+  }
+
   render() {
     const links = [];
     if (this.state.expend) {
@@ -173,18 +172,19 @@ let I13nComponentLevel2Hidden = createClass({
       </div>
     );
   }
-});
+}
 
 I13nComponentLevel2Hidden = createI13nNode(I13nComponentLevel2Hidden);
 
-let I13nDemo = createClass({
+class I13nDemo extends React.Component {
   componentWillMount() {
     ReactI13n.getInstance().execute('pageview', {});
-  },
+  }
+
   render() {
     return <I13nComponentLevel1 i13nModel={{ sec: 'level1' }} />;
   }
-});
+}
 
 window.firedEvents = [];
 


### PR DESCRIPTION
We shouldn't need to use the package anymore, can just use class.

![Screen Shot 2020-05-25 at 1 42 18 PM](https://user-images.githubusercontent.com/3906130/82843046-ba855180-9e90-11ea-9e8f-8c8845ad1188.png)


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


