### PR TITLE
YNEL-641 Adding code to check if element is in viewport to the right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.4",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -264,7 +264,10 @@ const prototypeSpecs = {
     const reactI13n = this._getReactI13n();
     const containerId = this._i13nNode._model.scrollableContainerId;
     const container = document.getElementById(containerId);
-    
+
+    if (container) {
+      reactI13n._scrollableContainerId = containerId;
+    }
     if (reactI13n.getScrollableContainerDOMNode) {
       const domNode = reactI13n.getScrollableContainerDOMNode();
       if (domNode) {

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -266,6 +266,10 @@ const prototypeSpecs = {
       const domNode = reactI13n.getScrollableContainerDOMNode();
       if (domNode) {
         options.target = domNode;
+        if (container){
+            options.touchMoveEndTarget=container;
+         
+        }
       }
     }
     return options;

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -262,13 +262,15 @@ const prototypeSpecs = {
       options.margins = margins;
     }
     const reactI13n = this._getReactI13n();
+    const containerId = this._i13nNode._model.scrollableContainerId;
+    const container = document.getElementById(containerId);
+    
     if (reactI13n.getScrollableContainerDOMNode) {
       const domNode = reactI13n.getScrollableContainerDOMNode();
       if (domNode) {
         options.target = domNode;
         if (container){
             options.touchMoveEndTarget=container;
-         
         }
       }
     }

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -269,8 +269,8 @@ const prototypeSpecs = {
       const domNode = reactI13n.getScrollableContainerDOMNode();
       if (domNode) {
         options.target = domNode;
-        if (container){
-            options.touchMoveEndTarget=container;
+        if (container) {
+            options.touchMoveEndTarget = container;
         }
       }
     }

--- a/src/libs/ComponentSpecs.js
+++ b/src/libs/ComponentSpecs.js
@@ -261,21 +261,20 @@ const prototypeSpecs = {
     if (margins) {
       options.margins = margins;
     }
-    const reactI13n = this._getReactI13n();
+    var reactI13n = this._getReactI13n();
     const containerId = this._i13nNode._model.scrollableContainerId;
-    const container = document.getElementById(containerId);
-
-    if (container) {
-      reactI13n._scrollableContainerId = containerId;
-    }
     if (reactI13n.getScrollableContainerDOMNode) {
-      const domNode = reactI13n.getScrollableContainerDOMNode();
-      if (domNode) {
-        options.target = domNode;
-        if (container) {
-            options.touchMoveEndTarget = container;
+        const domNode = reactI13n.getScrollableContainerDOMNode();
+        if (domNode) {
+            options.target = domNode;             
         }
-      }
+    }
+    if (containerId) {
+        const touchMoveEndTarget = document.getElementById(containerId);
+        if (touchMoveEndTarget) {
+            reactI13n._scrollableContainerId = containerId;
+            options.touchMoveEndTarget = touchMoveEndTarget;
+        }
     }
     return options;
   },

--- a/src/libs/ViewportDetector.js
+++ b/src/libs/ViewportDetector.js
@@ -58,8 +58,11 @@ ViewportDetector.prototype._detectViewport = function () {
   }
   const rect = this._element.getBoundingClientRect();
 
-// Detect Screen Bottom                           // Detect Screen Top                         //Detect Screen Right
-if (rect.top < innerHeight + this._margins.top && rect.bottom > 0 - this._margins.bottom && rect.right <= (window.innerWidth || document.documentElement.clientWidth)) {
+// Detect Screen Bottom                           // Detect Screen Top
+if (rect.top < innerHeight + this._margins.top && rect.bottom > 0 - this._margins.bottom &&
+    rect.left <= (window.pageXOffset + window.innerWidth) &&  //Detect screen left
+    rect.right <=(window.innerWidth || document.documentElement.clientWidth)){ //Detect if item fully in view horizontally
+    
     this._enteredViewport = true;
     this.unsubscribeAll();
     this._onEnterViewport && this._onEnterViewport();

--- a/src/libs/ViewportDetector.js
+++ b/src/libs/ViewportDetector.js
@@ -58,8 +58,8 @@ ViewportDetector.prototype._detectViewport = function () {
   }
   const rect = this._element.getBoundingClientRect();
 
-  // Detect Screen Bottom                           // Detect Screen Top
-  if (rect.top < innerHeight + this._margins.top && rect.bottom > 0 - this._margins.bottom) {
+// Detect Screen Bottom                           // Detect Screen Top                         //Detect Screen Right
+if (rect.top < innerHeight + this._margins.top && rect.bottom > 0 - this._margins.bottom && rect.right <= (window.innerWidth || document.documentElement.clientWidth)) {
     this._enteredViewport = true;
     this.unsubscribeAll();
     this._onEnterViewport && this._onEnterViewport();

--- a/src/libs/ViewportDetector.js
+++ b/src/libs/ViewportDetector.js
@@ -41,6 +41,7 @@ const ViewportDetector = function ViewportDetector(element, options, onEnterView
   this._options = Object.assign({}, SUBSCRIBE_OPTIONS);
   if (options.target) {
     this._options.target = options.target;
+    this._options.touchMoveEndTarget = options.touchMoveEndTarget;
   }
   this._enteredViewport = false;
 };
@@ -83,6 +84,10 @@ ViewportDetector.prototype.init = function (skipInitDetection) {
 
   if (!this._enteredViewport) {
     this._subscribers = [subscribe('scrollEnd', this._detectViewport.bind(this), this._options)];
+    if (this._options.touchMoveEndTarget) {
+      this._subscribers.push(subscribe('touchmoveEnd', this._detectViewport.bind(this), Object.assign({}, this._options, {target: this._options.touchMoveEndTarget})));
+      
+  }
   }
 };
 

--- a/src/libs/ViewportDetector.js
+++ b/src/libs/ViewportDetector.js
@@ -57,11 +57,11 @@ ViewportDetector.prototype._detectViewport = function () {
     return this._onEnterViewport && this._onEnterViewport();
   }
   const rect = this._element.getBoundingClientRect();
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
 
-// Detect Screen Bottom                           // Detect Screen Top
-if (rect.top < innerHeight + this._margins.top && rect.bottom > 0 - this._margins.bottom &&
-    rect.left <= (window.pageXOffset + window.innerWidth) &&  //Detect screen left
-    rect.right <=(window.innerWidth || document.documentElement.clientWidth)){ //Detect if item fully in view horizontally
+if (rect.top < innerHeight + this._margins.top &&  // Detect Screen Bottom 
+  rect.bottom > 0 - this._margins.bottom && // Detect Screen Top
+  rect.left < viewportWidth && rect.right > 0){ //Detect if in view horizontally
     
     this._enteredViewport = true;
     this.unsubscribeAll();

--- a/src/utils/createI13nNode.js
+++ b/src/utils/createI13nNode.js
@@ -16,7 +16,8 @@ const PROPS_TO_FILTER = [
   'follow',
   'i13nModel',
   'isLeafNode',
-  'scanLinks'
+  'scanLinks',
+  'touchMoveEndTargetId'
 ];
 
 const isFunctionalComponent = TargetComponent => typeof TargetComponent === 'function';


### PR DESCRIPTION
Currently on news.yahoo.com linkview beacons are being sent for 21 items in the steam even though viewability is enabled and the items in the stream are not in view until the user scrolls to the right in the carousel. Adding code to cater for items not in view horizontally.

![image](https://user-images.githubusercontent.com/5711011/94472625-e90a9480-01c2-11eb-86b3-8d99c0514012.png)


**news.yahoo.com currently - shows 22 items:**
![image](https://user-images.githubusercontent.com/5711011/94472768-21aa6e00-01c3-11eb-98ee-d91142fc5d89.png)
![image](https://user-images.githubusercontent.com/5711011/94472801-2ec75d00-01c3-11eb-88df-0c4f95d1b225.png)

**Local - after making change above - shows 6 items:**
![image](https://user-images.githubusercontent.com/5711011/94472910-5c140b00-01c3-11eb-93b6-7cfe3b591173.png)
![image](https://user-images.githubusercontent.com/5711011/94473258-dd6b9d80-01c3-11eb-9c24-1d80f58f7c4c.png)






<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
