### PR TITLE
Prevent setup plugins run multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/src/core/ReactI13n.js
+++ b/src/core/ReactI13n.js
@@ -129,6 +129,11 @@ class ReactI13n {
     this._eventsQueues[plugin.name] = new EventsQueue(plugin);
   }
 
+  cleanUpPlugins() {
+    this._eventsQueues = {};
+    this._plugins = {};
+  }
+
   /**
    * Get handlers from all plugin by event name
    * @method getEventHandlers

--- a/src/core/setupI13n.jsx
+++ b/src/core/setupI13n.jsx
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import getDisplayName from '../utils/getDisplayName';
@@ -53,12 +53,18 @@ function setupI13n(Component, options = {}, plugins = []) {
       executeI13nEvent: executeEvent
     } = useReactI13nRoot(options);
 
-    if (reactI13n) {
-      plugins.forEach((plugin) => {
-        reactI13n.plug(plugin);
-      });
-      reactI13n.createRootI13nNode();
-    }
+    useEffect(() => {
+      if (reactI13n) {
+        plugins.forEach((plugin) => {
+          reactI13n.plug(plugin);
+        });
+        reactI13n.createRootI13nNode();
+      }
+
+      return () => {
+        reactI13n?.cleanUpPlugins();
+      };
+    }, [reactI13n, plugins]);
 
     const parentI13nNode = reactI13n?.getRootI13nNode();
 


### PR DESCRIPTION
I notice that the `setupI13n` will now execute multiple times on top level app re-render (such as route change) even if the plugins or reactI13n instance are the same as we put the function in render.

Change to `useEffect` and also create life cycle to clean up plugins to prevent memory leaks

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
