### PR TITLE
FIx process.env usage in variables

### DIFF
--- a/src/utils/variables.js
+++ b/src/utils/variables.js
@@ -4,10 +4,8 @@
  */
 import isUndefined from './isUndefined';
 
-const { NODE_ENV } = process.env;
-
-export const IS_PROD = NODE_ENV === 'production';
-export const IS_TEST = NODE_ENV === 'test';
+export const IS_PROD = process.env.NODE_ENV === 'production';
+export const IS_TEST = process.env.NODE_ENV === 'test';
 export const IS_CLIENT = typeof window !== 'undefined';
 export const ENVIRONMENT = IS_CLIENT ? 'client' : 'server';
 

--- a/src/utils/variables.js
+++ b/src/utils/variables.js
@@ -4,8 +4,11 @@
  */
 import isUndefined from './isUndefined';
 
-export const IS_PROD = process.env.NODE_ENV === 'production';
-export const IS_TEST = process.env.NODE_ENV === 'test';
+// eslint-disable-next-line prefer-destructuring
+const NODE_ENV = process.env.NODE_ENV;
+
+export const IS_PROD = NODE_ENV === 'production';
+export const IS_TEST = NODE_ENV === 'test';
 export const IS_CLIENT = typeof window !== 'undefined';
 export const ENVIRONMENT = IS_CLIENT ? 'client' : 'server';
 


### PR DESCRIPTION
👋 small fix - in Webpack, `DefinePlugin` replaces full variable expressions (i.e. `process.env.NODE_ENV`) but can't detect implied destructured values (i.e. `const { NODE_ENV } = process.env`). This PR just changes some `process.env` usages to use full expressions.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
