### PR TITLE
Fix event target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-i13n",
   "description": "React I13n provides a performant and scalable solution to application instrumentation.",
-  "version": "3.0.0-alpha.7",
+  "version": "3.0.0-alpha.8",
   "main": "index.js",
   "module": "index.es.js",
   "repository": {

--- a/src/libs/clickHandler.js
+++ b/src/libs/clickHandler.js
@@ -2,13 +2,13 @@
  * Copyright 2015 - Present, Yahoo Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-const isLeftClickEvent = e => e.button === 0;
-const isModifiedEvent = e => !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
+const isLeftClickEvent = (e) => e.button === 0;
+const isModifiedEvent = (e) => !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
 
 const getLinkTarget = (target, props) => props.target || (target?.target) || '_self';
 const isNewWindow = (target, props) => getLinkTarget(target, props) === '_blank';
 
-const isLink = target => target.tagName === 'A';
+const isLink = (target) => target.tagName === 'A';
 const isButtonLike = (target) => {
   const { tagName, type } = target;
   if (tagName === 'BUTTON') {
@@ -49,7 +49,7 @@ const isFormSubmit = (target) => {
  * @method ClickHandler
  */
 const clickHandler = (e, options = {}) => {
-  const target = e.target || e.srcElement;
+  const target = e.currentTarget;
   const isForm = isFormSubmit(target);
 
   let isRedirectLink = isDefaultRedirectLink(target);

--- a/src/libs/clickHandler.js
+++ b/src/libs/clickHandler.js
@@ -37,7 +37,7 @@ const isFormSubmit = (target) => {
   // if it's a
   // 1. button
   // 2. input with submit or button type
-  if (isButtonLike(target)) {
+  if (isButtonLike(target) && target.type === 'submit') {
     return true;
   }
   return false;
@@ -79,7 +79,7 @@ const clickHandler = (e, options = {}) => {
   if (
     (!isDefaultRedirectLink(target))
     || (isLink(target) && (!href || (href && href[0] === '#')))
-    || (isButtonLike(target) && !target.form)
+    || (isButtonLike(target) && !isForm)
   ) {
     isRedirectLink = false;
     isPreventDefault = false;

--- a/src/libs/tests/clickHandler.test.js
+++ b/src/libs/tests/clickHandler.test.js
@@ -37,7 +37,7 @@ describe('clickHandler', () => {
     };
 
     mockClickEvent = {
-      target: {},
+      currentTarget: {},
       button: 0,
       preventDefault: jest.fn()
     };
@@ -72,7 +72,7 @@ describe('clickHandler', () => {
       done();
     };
 
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A',
       href: 'https://foobar.com'
     };
@@ -88,7 +88,7 @@ describe('clickHandler', () => {
   it('should run click handler correctly if target is an button', (done) => {
     const executedActions = [];
 
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'BUTTON',
       form: {
         submit() {
@@ -111,7 +111,7 @@ describe('clickHandler', () => {
 
   it('should run click handler correctly if target is input with submit', (done) => {
     const executedActions = [];
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'INPUT',
       type: 'submit',
       form: {
@@ -135,7 +135,7 @@ describe('clickHandler', () => {
 
   it('should not follow it if follow is set to false', (done) => {
     const executedActions = [];
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A',
       href: 'https://foobar.com'
     };
@@ -154,7 +154,7 @@ describe('clickHandler', () => {
 
   it('should follow it while follow is set to true', (done) => {
     const executedActions = [];
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A',
       href: 'https://foobar.com'
     };
@@ -178,7 +178,7 @@ describe('clickHandler', () => {
 
   it('should simply execute event without prevent default and redirection if the link is #', (done) => {
     const executedActions = [];
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A'
     };
     mockClickEvent.preventDefault = function () {
@@ -196,7 +196,7 @@ describe('clickHandler', () => {
 
   it('should simply execute event without prevent default and redirection is a modified click', (done) => {
     const executedActions = [];
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A'
     };
     mockClickEvent.metaKey = true;
@@ -215,7 +215,7 @@ describe('clickHandler', () => {
 
   it('should simply execute event without prevent default and redirection if props.target=_blank', (done) => {
     const executedActions = [];
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'SPAN'
     };
     mockClickEvent.preventDefault = function () {
@@ -237,7 +237,7 @@ describe('clickHandler', () => {
       executedActions.push('assign');
     };
 
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A',
       href: 'foo'
     };
@@ -262,7 +262,7 @@ describe('clickHandler', () => {
       executedActions.push('assign');
     };
 
-    mockClickEvent.target = {
+    mockClickEvent.currentTarget = {
       tagName: 'A',
       href: 'foo'
     };

--- a/src/libs/tests/clickHandler.test.js
+++ b/src/libs/tests/clickHandler.test.js
@@ -90,6 +90,7 @@ describe('clickHandler', () => {
 
     mockClickEvent.currentTarget = {
       tagName: 'BUTTON',
+      type: 'submit',
       form: {
         submit() {
           executedActions.push('submit');

--- a/src/utils/isUndefined.js
+++ b/src/utils/isUndefined.js
@@ -3,6 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-const isUndefined = data => typeof data === 'undefined';
+const isUndefined = (data) => typeof data === 'undefined';
 
 export default isUndefined;


### PR DESCRIPTION
1. In click handler we directly check if the target node is button/anchor, this should be `currentTarget` instead of `target` or else some case like `keyboard enter` for a button component will not identify as `button` as the target will be the child.
2. We only check if a button tag has `form` and submit it by default without checking the `type` of the button. If a button (with type `button` specified), javascript will still attach `form` object to the element, but browser won't auto submit it when clicking it. To align with the browser behavior, I'm adding check to prevent auto-submit parent form if the button type is not `submit` (default) 

All child component for auto scan case should already attached different listeners. (we are not using capture in the click handler)

----
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
