### PR TITLE
Fix issue: after setup an i13nAnchor component, wrongly get an root i13nNode in created event handler of existing plugins (ex. Rapid Plugin)

### DIFF
--- a/src/components/core/CoreComponent.jsx
+++ b/src/components/core/CoreComponent.jsx
@@ -46,7 +46,7 @@ const CoreComponent = (props) => {
 
   // create event
   useEffect(() => {
-    executeEvent?.('created', {});
+    executeEvent?.('created', { i13nNode: i13nNode || parentI13nNode });
   }, []);
 
   // auto bind click event


### PR DESCRIPTION
# Fix the issue: 
After setup an `i13nAnchor` component,  wrongly get an root i13nNode in `created` event handler of existing plugins (ex. Rapid Plugin)
### 3.x version: payload.i13nNode is a root node (Unexpected: _DOMNode is body)
![2E7276E9-3D64-49BD-9794-F36DFA5794BB](https://user-images.githubusercontent.com/1962079/134661916-db01af4b-5bee-4866-a224-ea69bed67098.png)

### 2.x version: payload.i13nNode a correct node (Expected: _DOMNode is a)
![90521513-772A-4ABC-97E1-9E9189924309](https://user-images.githubusercontent.com/1962079/134661939-d5ca1ee9-3c7e-4495-94d3-c34403aa308a.png)

It causes Rapid plugin be broken for initialized LinkView because no correct i13node and related model

# Root Cause
### In the 2.x version
After executeI13nEvent with an empty object in `comoonentDidMount`
https://github.com/yahoo/react-i13n/blob/2.x/src/libs/ComponentSpecs.js#L161

payload.i13nNode will run a fallback for getting a i13nNode
https://github.com/yahoo/react-i13n/blob/3697f874780ba78ceb38431c75240ea422ee5784/src/libs/ComponentSpecs.js#L235

And it will return current i13nNode or parentI13nNode
```
 this._i13nNode || this._getParentI13nNode();
```
So payload will have current i13nNode (_i13nNode) before sending to handler
![image](https://user-images.githubusercontent.com/1962079/134657572-c203d870-494a-48f6-b96c-37851153924e.png)


### But in 3.x version
After executEvent with an empty object.
from [useEffect](https://github.com/yahoo/react-i13n/blob/master/src/components/core/CoreComponent.jsx#L49)

to [executeI13nEvent](https://github.com/yahoo/react-i13n/blob/master/src/hooks/useReactI13nRoot.js#L41)
![image](https://user-images.githubusercontent.com/1962079/134658125-fc99f5cb-3a04-459a-a696-1dd25603890b.png)

and than to [executeEvent](https://github.com/yahoo/react-i13n/blob/cb8d8f9b712636e646f90b6de8eb84d554e97dd1/src/libs/EventsQueue.js#L59)
![image](https://user-images.githubusercontent.com/1962079/134657078-3876b3e1-8ad8-44de-b6a1-590d2f0912a8.png)

Nowhere do the same fallback logic before sending the event, so payload.i13nNode become to a root node.
I believe it's a unexpected result otherwise causing a huge breaking changes for all plugins which wants do something with i13nNode.

### Note.
I also saw there is [related code commented out](https://github.com/yahoo/react-i13n/blob/master/src/hooks/useReactI13nRoot.js#L41]) in executeI13nEvent method in 3.x version, but it seems impossible to get both current i13nNode and parenti13nNode, so I moved the fix to the effect function in this PR.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
