### PR TITLE
Fix the wrong i13nNode in the init created event payload

### DIFF
--- a/src/components/core/CoreComponent.jsx
+++ b/src/components/core/CoreComponent.jsx
@@ -46,7 +46,7 @@ const CoreComponent = (props) => {
 
   // create event
   useEffect(() => {
-    executeEvent?.('created', {});
+    executeEvent?.('created', { i13nNode });
   }, []);
 
   // auto bind click event


### PR DESCRIPTION
For the issue: https://github.com/yahoo/react-i13n/issues/426

I thought the best solution is replace [the code](https://github.com/yahoo/react-i13n/blob/master/src/core/ReactI13n.js#L84) by [2.x's implementation](https://github.com/yahoo/react-i13n/blob/2.x/src/libs/ComponentSpecs.js#L235), but I did not find any ways to get correct `this._i13nNode`, it looks like [a cached node in createI13Node in 2.x](https://github.com/yahoo/react-i13n/blob/2.x/src/libs/ComponentSpecs.js#L481), but because of the implementation changes, it has been [put in context in 3.x](https://github.com/yahoo/react-i13n/blob/01106beadfe879b46b9704a83bcd7eda19e05416/src/core/createI13nNode.jsx#L97).

So My PR is just passing the i13nNode from context in CoreComponent to the event payload.
If there are any better ideas, please kindly let me know, thanks a lot 🙂

