### PR TITLE
Suppress `useLayoutEffect` rehydration warning in `useDebugDashboard`

### DIFF
--- a/src/hooks/useDebugDashboard.js
+++ b/src/hooks/useDebugDashboard.js
@@ -3,17 +3,18 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { useLayoutEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import { IS_DEBUG_MODE } from '../utils/variables';
 import DebugDashboard from '../libs/DebugDashboard';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 const useDebugDashboard = ({
   node
 }) => {
   const debugDashboard = useRef();
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (IS_DEBUG_MODE) {
       debugDashboard.current = new DebugDashboard(node);
     }

--- a/src/hooks/useIsomorphicLayoutEffect.js
+++ b/src/hooks/useIsomorphicLayoutEffect.js
@@ -1,0 +1,5 @@
+import { useLayoutEffect, useEffect } from 'react';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
👋  trying to use react-i13n in an SSR environment and am getting this warning in dev:

> ⚠️ Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer’s output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://fb.me/react-uselayouteffect-ssr for common fixes.

This is a fairly common issue - in this case, it's a false alarm since `useDebugDashboard`'s `useLayoutEffect` usage won't affect the rehydrated React tree. A common solution is to use a custom [useIsomorphicLayoutEffect](https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a) hook which only calls `useLayoutEffect` on the client, as seen in libraries like [react-redux](https://github.com/reduxjs/react-redux/blob/4d384029e3fa0355e762f40409a5dac4358a3de3/src/utils/useIsomorphicLayoutEffect.ts).

I'm fairly certain this will be a functional noop, though please double check me!

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
